### PR TITLE
Populate additional fields in Price struct to be compatible with Pyth SDK

### DIFF
--- a/programs/pyth/src/lib.rs
+++ b/programs/pyth/src/lib.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 mod pc;
-use pc::Price;
+use pc::{AccountType, Price, MAGIC, VERSION};
+
+use borsh::{BorshDeserialize, BorshSerialize};
 
 #[cfg(feature = "mainnet-beta")]
 declare_id!("GWXu4vLvXFN87dePFvM7Ejt8HEALEG9GNmwimNKHZrXG");
@@ -16,9 +18,12 @@ pub mod pyth {
 
         let mut price_oracle = Price::load(oracle).unwrap();
 
+        price_oracle.magic = MAGIC;
+        price_oracle.ver = VERSION;
+        price_oracle.atype = AccountType::Price;
+
         price_oracle.agg.price = price;
         price_oracle.agg.conf = conf;
-        price_oracle.agg.conf = 0;
         price_oracle.valid_slot = 228506959; //todo just turned 1->2 for negative delay
 
         price_oracle.twap = price;
@@ -38,6 +43,12 @@ pub mod pyth {
             .checked_div(2)
             .unwrap(); //todo
         price_oracle.agg.price = price as i64;
+
+        let clock = Clock::get().unwrap();
+
+        price_oracle.curr_slot = clock.slot;
+        price_oracle.valid_slot = clock.slot;
+
         Ok(())
     }
 

--- a/programs/pyth/src/pc.rs
+++ b/programs/pyth/src/pc.rs
@@ -3,6 +3,26 @@ use anchor_lang::prelude::AccountInfo;
 use bytemuck::{cast_slice_mut, from_bytes_mut, try_cast_slice_mut, Pod, Zeroable};
 use std::cell::RefMut;
 
+pub const MAGIC: u32 = 0xa1b2c3d4;
+pub const VERSION_2: u32 = 2;
+pub const VERSION: u32 = VERSION_2;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+#[allow(dead_code, clippy::upper_case_acronyms)]
+pub enum AccountType {
+    Unknown,
+    Mapping,
+    Product,
+    Price,
+}
+
+impl Default for AccountType {
+    fn default() -> Self {
+        AccountType::Price
+    }
+}
+
 #[derive(Default, Copy, Clone)]
 #[repr(C)]
 pub struct AccKey {
@@ -73,13 +93,13 @@ impl Default for PriceType {
 #[derive(Default, Copy, Clone)]
 #[repr(C)]
 pub struct Price {
-    pub magic: u32,       // Pyth magic number.
-    pub ver: u32,         // Program version.
-    pub atype: u32,       // Account type.
-    pub size: u32,        // Price account size.
-    pub ptype: PriceType, // Price or calculation type.
-    pub expo: i32,        // Price exponent.
-    pub num: u32,         // Number of component prices.
+    pub magic: u32,         // Pyth magic number.
+    pub ver: u32,           // Program version.
+    pub atype: AccountType, // Account type.
+    pub size: u32,          // Price account size.
+    pub ptype: PriceType,   // Price or calculation type.
+    pub expo: i32,          // Price exponent.
+    pub num: u32,           // Number of component prices.
     pub unused: u32,
     pub curr_slot: u64,        // Currently accumulating price slot.
     pub valid_slot: u64,       // Valid slot-time of agg. price.


### PR DESCRIPTION
Added the following to initialize:

        price_oracle.magic = MAGIC;
        price_oracle.ver = VERSION;
        price_oracle.atype = AccountType::Price;

Added the following to set_price:

        price_oracle.curr_slot = clock.slot;
        price_oracle.valid_slot = clock.slot;
