### PR TITLE
Bigz/ calculate budgeted k scale fix

### DIFF
--- a/sdk/src/math/amm.ts
+++ b/sdk/src/math/amm.ts
@@ -279,16 +279,6 @@ export function calculateSpread(
 		const netCostBasis = amm.quoteAssetAmountLong.sub(
 			amm.quoteAssetAmountShort
 		);
-		// console.log(
-		// 	'amm.netBaseAssetAmount:',
-		// 	amm.netBaseAssetAmount.toString(),
-		// 	'terminalQuoteAssetReserve:',
-		// 	amm.terminalQuoteAssetReserve.toString(),
-		// 	'quoteAssetReserve:',
-		// 	amm.quoteAssetReserve.toString(),
-		// 	'pegMultiplier:',
-		// 	amm.pegMultiplier.toString()
-		// );
 		const netBaseAssetValue = amm.quoteAssetReserve
 			.sub(amm.terminalQuoteAssetReserve)
 			.mul(amm.pegMultiplier)
@@ -297,25 +287,8 @@ export function calculateSpread(
 		const localBaseAssetValue = amm.netBaseAssetAmount
 			.mul(markPrice)
 			.div(AMM_TO_QUOTE_PRECISION_RATIO.mul(MARK_PRICE_PRECISION));
-		// console.log(
-		// 	'localBAV:',
-		// 	localBaseAssetValue.toString(),
-		// 	'netBAV:',
-		// 	netBaseAssetValue.toString(),
-		// 	'netCostBasis:',
-		// 	netCostBasis.toString()
-		// );
 		const netPnl = netBaseAssetValue.sub(netCostBasis);
 		const localPnl = localBaseAssetValue.sub(netCostBasis);
-
-		// console.log(
-		// 	'localPnl:',
-		// 	localPnl.toString(),
-		// 	'netPnl:',
-		// 	netPnl.toString(),
-		// 	'netCostBasis:',
-		// 	netCostBasis.toString()
-		// );
 
 		let effectiveLeverage = MAX_INVENTORY_SKEW;
 		if (amm.totalFeeMinusDistributions.gt(ZERO)) {

--- a/sdk/src/math/repeg.ts
+++ b/sdk/src/math/repeg.ts
@@ -54,58 +54,12 @@ export function calculateAdjustKCost(
  * @returns cost : Precision QUOTE_ASSET_PRECISION
  */
 export function calculateRepegCost(amm: AMM, newPeg: BN): BN {
-	// const dqar = amm.quoteAssetAmountLong.sub(amm.quoteAssetAmountShort);
 	const dqar = amm.quoteAssetReserve.sub(amm.terminalQuoteAssetReserve);
 	const cost = dqar
 		.mul(newPeg.sub(amm.pegMultiplier))
 		.div(AMM_TO_QUOTE_PRECISION_RATIO)
 		.div(PEG_PRECISION);
-	// console.log('dqar cost', dqar, cost);
 	return cost;
-}
-
-export function calculateBudgetedKN2(
-	x: BN,
-	y: BN,
-	budget: BN,
-	Q: BN,
-	d: BN
-): [BN, BN] {
-	assert(Q.gt(new BN(0)));
-	const C = budget.mul(new BN(-1));
-
-	const numer1 = y.mul(d).mul(Q).div(AMM_RESERVE_PRECISION).div(PEG_PRECISION);
-	const numer2 = C.mul(x.add(d)).div(QUOTE_PRECISION);
-	const denom1 = C.mul(x)
-		.mul(x.add(d))
-		.div(AMM_RESERVE_PRECISION)
-		.div(QUOTE_PRECISION);
-	const denom2 = y
-		.mul(d)
-		.mul(d)
-		.mul(Q)
-		.div(AMM_RESERVE_PRECISION)
-		.div(AMM_RESERVE_PRECISION)
-		.div(PEG_PRECISION);
-
-	console.log(
-		'\n',
-		numer1.mul(d).div(AMM_RESERVE_PRECISION).toString(),
-		'-',
-		numer2.mul(d.div(AMM_RESERVE_PRECISION)).toString(),
-		'/',
-		denom1.toString(),
-		'+',
-		denom2.toString()
-	);
-
-	const numerator = d
-		.mul(numer1.sub(numer2))
-		.div(AMM_RESERVE_PRECISION)
-		.div(AMM_TO_QUOTE_PRECISION_RATIO);
-	const denominator = denom1.add(denom2).div(AMM_TO_QUOTE_PRECISION_RATIO);
-
-	return [numerator, denominator];
 }
 
 export function calculateBudgetedKN(
@@ -137,24 +91,11 @@ export function calculateBudgetedKN(
 		.div(AMM_RESERVE_PRECISION)
 		.mul(dSign);
 
-	// C.mul(x.add(d)).div(QUOTE_PRECISION);
-
 	const denom1 = C.mul(x)
 		.mul(x.add(d))
 		.div(AMM_RESERVE_PRECISION)
 		.div(QUOTE_PRECISION);
 	const denom2 = pegged_y_d_d;
-
-	console.log(
-		'\n',
-		numer1.toString(),
-		'-',
-		numer2.toString(),
-		'/',
-		denom1.toString(),
-		'+',
-		denom2.toString()
-	);
 
 	const numerator = numer1.sub(numer2).div(AMM_TO_QUOTE_PRECISION_RATIO);
 	const denominator = denom1.add(denom2).div(AMM_TO_QUOTE_PRECISION_RATIO);

--- a/sdk/src/math/trade.ts
+++ b/sdk/src/math/trade.ts
@@ -106,15 +106,6 @@ export function calculateTradeSlippage(
 		amm.pegMultiplier
 	).mul(new BN(-1));
 
-	// console.log(
-	// 	'entryPrice:',
-	// 	entryPrice.toString(),
-	// 	'(',
-	// 	acquiredBase.toString(),
-	// 	acquiredQuote.toString(),
-	// 	')'
-	// );
-
 	const newPrice = calculatePrice(
 		amm.baseAssetReserve.sub(acquiredBase),
 		amm.quoteAssetReserve.sub(acquiredQuote),

--- a/tests/updateK.ts
+++ b/tests/updateK.ts
@@ -18,6 +18,7 @@ import {
 	PositionDirection,
 	convertToNumber,
 	squareRootBN,
+	calculateBudgetedKN,
 } from '../sdk/src';
 
 import {
@@ -534,5 +535,72 @@ describe('update k', () => {
 			'USER getTotalCollateral',
 			convertToNumber(userAccount.getTotalCollateral(), QUOTE_PRECISION)
 		);
+	});
+
+	it('budget k change (sdk math)', async () => {
+		// pay $.11 to increase k
+		let [numer1, denom1] = calculateBudgetedKN(
+			new BN('49750000004950'), // x
+			new BN('50250000000000'), // y
+			new BN('114638'), // cost
+			new BN('40000'), // peg
+			new BN('49750000004950') // net position
+		);
+		console.log(numer1.toString(), '/', denom1.toString());
+
+		assert(numer1.eq(new BN(4980550350)));
+		assert(denom1.eq(new BN(4969200901)));
+
+		// gain $.11 by decreasing k
+		[numer1, denom1] = calculateBudgetedKN(
+			new BN('49750000004950'), // x
+			new BN('50250000000000'), // y
+			new BN('-114638'), // cost
+			new BN('40000'), // peg
+			new BN('49750000004950') // net position
+		);
+		console.log(numer1.toString(), '/', denom1.toString());
+		assert(numer1.eq(new BN(4969200901)));
+		assert(denom1.eq(new BN(4980550350)));
+		assert(numer1.lt(denom1));
+
+		// pay $11 to increase k
+		[numer1, denom1] = calculateBudgetedKN(
+			new BN('49750000004950'),
+			new BN('50250000000000'),
+			new BN('11463800'),
+			new BN('40000'),
+			new BN('49750000004950')
+		);
+		console.log(numer1.toString(), '/', denom1.toString());
+
+		assert(numer1.eq(new BN(5542348055)));
+		assert(denom1.eq(new BN(4407403196)));
+		assert(numer1.gt(denom1));
+
+		// net pos so small that decreasing k for .01 is sending to zero (squeezing a stone)
+		[numer1, denom1] = calculateBudgetedKN(
+			new BN('500000000049750000004950'),
+			new BN('499999999950250000000000'),
+			new BN('-10000'),
+			new BN('40000'),
+			new BN('-49750000004950')
+		);
+		console.log(numer1.toString(), '/', denom1.toString());
+
+		assert(numer1.eq(new BN('49498762504924880624')));
+		assert(denom1.eq(new BN('25000049503737504925373124')));
+
+		// impossible task trying to spend more than amount to make k infinity
+		[numer1, denom1] = calculateBudgetedKN(
+			new BN('500000000049750000004950'),
+			new BN('499999999950250000000000'),
+			new BN('10000'),
+			new BN('40000'),
+			new BN('-49750000004950')
+		);
+		console.log(numer1.toString(), '/', denom1.toString());
+
+		assert(denom1.lt(new BN(0))); // throws negative
 	});
 });


### PR DESCRIPTION
calculateBudgetedK  is actually unstable for sufficiently small values of net_user_base_asset_amount relative to the reserves and will spit out extreme values. thats because there is no increase in k that would cost up to $C, since the net position is so small. so its impossible to spend cost C

the exact boundary might be a bit complex but its when the sign of the denom and numerator dont match up.
<img width="393" alt="Screen Shot 2022-07-08 at 4 56 31 PM" src="https://user-images.githubusercontent.com/83473873/178069182-48a9bc13-6afa-4605-b56e-363aa874332b.png">
 