### PR TITLE
clearing_house: user stats init

### DIFF
--- a/programs/clearing_house/src/context.rs
+++ b/programs/clearing_house/src/context.rs
@@ -5,7 +5,7 @@ use crate::controller::position::PositionDirection;
 use crate::state::bank::Bank;
 use crate::state::market::Market;
 use crate::state::state::State;
-use crate::state::user::{OrderTriggerCondition, OrderType, User};
+use crate::state::user::{OrderTriggerCondition, OrderType, User, UserStats};
 
 #[derive(Accounts)]
 pub struct Initialize<'info> {
@@ -77,6 +77,24 @@ pub struct InitializeBank<'info> {
 }
 
 #[derive(Accounts)]
+pub struct InitializeUserStats<'info> {
+    #[account(
+        init,
+        seeds = [b"user_stats", authority.key.as_ref()],
+        space = std::mem::size_of::<UserStats>() + 8,
+        bump,
+        payer = payer
+    )]
+    pub user_stats: AccountLoader<'info, UserStats>,
+    pub state: Box<Account<'info, State>>,
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub rent: Sysvar<'info, Rent>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
 #[instruction(
     user_id: u8,
 )]
@@ -89,6 +107,11 @@ pub struct InitializeUser<'info> {
         payer = payer
     )]
     pub user: AccountLoader<'info, User>,
+    #[account(
+        mut,
+        has_one = authority
+    )]
+    pub user_stats: AccountLoader<'info, UserStats>,
     pub state: Box<Account<'info, State>>,
     pub authority: Signer<'info>,
     #[account(mut)]
@@ -329,6 +352,11 @@ pub struct PlaceOrder<'info> {
         has_one = authority,
     )]
     pub user: AccountLoader<'info, User>,
+    #[account(
+        mut,
+        has_one = authority,
+    )]
+    pub user_stats: AccountLoader<'info, UserStats>,
     pub authority: Signer<'info>,
 }
 

--- a/programs/clearing_house/src/lib.rs
+++ b/programs/clearing_house/src/lib.rs
@@ -1603,6 +1603,28 @@ pub mod clearing_house {
             next_liquidation_id: 1,
             ..User::default()
         };
+
+        let mut user_stats = load_mut!(ctx.accounts.user_stats)?;
+        user_stats.number_of_users = user_stats
+            .number_of_users
+            .checked_add(1)
+            .ok_or_else(math_error!())?;
+
+        Ok(())
+    }
+
+    pub fn initialize_user_stats(ctx: Context<InitializeUserStats>) -> Result<()> {
+        let mut user_stats = ctx
+            .accounts
+            .user_stats
+            .load_init()
+            .or(Err(ErrorCode::UnableToLoadAccountLoader))?;
+
+        *user_stats = UserStats {
+            authority: ctx.accounts.authority.key(),
+            number_of_users: 0,
+        };
+
         Ok(())
     }
 

--- a/programs/clearing_house/src/state/user.rs
+++ b/programs/clearing_house/src/state/user.rs
@@ -454,3 +454,11 @@ impl Default for OrderTriggerCondition {
         OrderTriggerCondition::Above
     }
 }
+
+#[account(zero_copy)]
+#[derive(Default, Eq, PartialEq, Debug)]
+#[repr(packed)]
+pub struct UserStats {
+    pub authority: Pubkey,
+    pub number_of_users: u8,
+}

--- a/sdk/src/accounts/fetch.ts
+++ b/sdk/src/accounts/fetch.ts
@@ -1,6 +1,9 @@
 import { Connection, PublicKey } from '@solana/web3.js';
-import { UserAccount } from '../types';
-import { getUserAccountPublicKey } from '../addresses/pda';
+import { UserAccount, UserStatsAccount } from '../types';
+import {
+	getUserAccountPublicKey,
+	getUserStatsAccountPublicKey,
+} from '../addresses/pda';
 import { Program } from '@project-serum/anchor';
 
 export async function fetchUserAccounts(
@@ -30,4 +33,26 @@ export async function fetchUserAccounts(
 			accountInfo.data
 		) as UserAccount;
 	});
+}
+
+export async function fetchUserStatsAccount(
+	connection: Connection,
+	program: Program,
+	authority: PublicKey
+): Promise<UserStatsAccount | undefined> {
+	const userStatsPublicKey = getUserStatsAccountPublicKey(
+		program.programId,
+		authority
+	);
+	const accountInfo = await connection.getAccountInfo(
+		userStatsPublicKey,
+		'confirmed'
+	);
+
+	return accountInfo
+		? (program.account.user.coder.accounts.decode(
+				'UserStats',
+				accountInfo.data
+		  ) as UserStatsAccount)
+		: undefined;
 }

--- a/sdk/src/addresses/pda.ts
+++ b/sdk/src/addresses/pda.ts
@@ -57,6 +57,19 @@ export function getUserAccountPublicKeySync(
 	)[0];
 }
 
+export function getUserStatsAccountPublicKey(
+	programId: PublicKey,
+	authority: PublicKey
+): PublicKey {
+	return anchor.web3.PublicKey.findProgramAddressSync(
+		[
+			Buffer.from(anchor.utils.bytes.utf8.encode('user_stats')),
+			authority.toBuffer(),
+		],
+		programId
+	)[0];
+}
+
 export async function getMarketPublicKey(
 	programId: PublicKey,
 	marketIndex: BN

--- a/sdk/src/idl/clearing_house.json
+++ b/sdk/src/idl/clearing_house.json
@@ -386,6 +386,11 @@
           "isSigner": false
         },
         {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
           "name": "authority",
           "isMut": false,
           "isSigner": true
@@ -1064,6 +1069,11 @@
           "isSigner": false
         },
         {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
           "name": "state",
           "isMut": false,
           "isSigner": false
@@ -1104,6 +1114,42 @@
           }
         }
       ]
+    },
+    {
+      "name": "initializeUserStats",
+      "accounts": [
+        {
+          "name": "userStats",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     },
     {
       "name": "settleFundingPayment",
@@ -2274,6 +2320,22 @@
           {
             "name": "beingLiquidated",
             "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStats",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "numberOfUsers",
+            "type": "u8"
           }
         ]
       }
@@ -4485,6 +4547,16 @@
     },
     {
       "code": 6100,
+      "name": "InvalidPositionLastFundingRate",
+      "msg": "InvalidPositionLastFundingRate"
+    },
+    {
+      "code": 6101,
+      "name": "InvalidPositionDelta",
+      "msg": "InvalidPositionDelta"
+    },
+    {
+      "code": 6102,
       "name": "DefaultError",
       "msg": "DefaultError"
     }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -392,6 +392,10 @@ export type UserPosition = {
 	openAsks: BN;
 };
 
+export type UserStatsAccount = {
+	numberOfUsers: number;
+};
+
 export type UserAccount = {
 	authority: PublicKey;
 	name: number[];

--- a/tests/subaccounts.ts
+++ b/tests/subaccounts.ts
@@ -10,6 +10,7 @@ import {
 	BN,
 	EventSubscriber,
 	fetchUserAccounts,
+	fetchUserStatsAccount,
 } from '../sdk/src';
 
 import {
@@ -72,6 +73,14 @@ describe('subaccounts', () => {
 
 		assert(clearingHouse.getUserAccount().userId === userId);
 		assert(decodeName(clearingHouse.getUserAccount().name) === name);
+
+		const userStats = await fetchUserStatsAccount(
+			connection,
+			clearingHouse.program,
+			provider.wallet.publicKey
+		);
+
+		assert(userStats.numberOfUsers === 1);
 	});
 
 	it('Initialize second account', async () => {
@@ -83,6 +92,14 @@ describe('subaccounts', () => {
 
 		assert(clearingHouse.getUserAccount().userId === userId);
 		assert(decodeName(clearingHouse.getUserAccount().name) === name);
+
+		const userStats = await fetchUserStatsAccount(
+			connection,
+			clearingHouse.program,
+			provider.wallet.publicKey
+		);
+
+		assert(userStats.numberOfUsers === 2);
 	});
 
 	it('Fetch all user account', async () => {


### PR DESCRIPTION
new account to track user stats across user subaccounts e.g. rolling 30 days volume