### PR TITLE
DataRaptor/Devnet TokenFaucet Constraints

### DIFF
--- a/programs/token_faucet/src/lib.rs
+++ b/programs/token_faucet/src/lib.rs
@@ -13,7 +13,11 @@ pub mod token_faucet {
     use anchor_spl::token::MintTo;
     use anchor_spl::token::SetAuthority;
 
-    pub fn initialize(ctx: Context<InitializeFaucet>) -> Result<()> {
+    pub fn initialize(
+        ctx: Context<InitializeFaucet>,
+        max_amount_mint: u64,
+        max_amount_per_user: u64,
+    ) -> Result<()> {
         let mint_account_key = ctx.accounts.mint_account.to_account_info().key;
         let (mint_authority, mint_authority_nonce) = Pubkey::find_program_address(
             &[b"mint_authority".as_ref(), mint_account_key.as_ref()],
@@ -33,6 +37,8 @@ pub mod token_faucet {
             mint: *mint_account_key,
             mint_authority,
             mint_authority_nonce,
+            max_amount_mint,
+            max_amount_per_user,
         };
 
         Ok(())
@@ -105,14 +111,21 @@ pub struct FaucetConfig {
     pub mint: Pubkey,
     pub mint_authority: Pubkey,
     pub mint_authority_nonce: u8,
+    pub max_amount_mint: u64,
+    pub max_amount_per_user: u64,
 }
 
 #[derive(Accounts)]
+#[instruction(amount: u64, max_amount_mint: u64)]
 pub struct MintToUser<'info> {
     pub faucet_config: Box<Account<'info, FaucetConfig>>,
     #[account(mut)]
     pub mint_account: Box<Account<'info, Mint>>,
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = amount < max_amount_mint,
+        constraint = user_token_account.amount < faucet_config.max_amount_per_user,
+    )]
     pub user_token_account: Box<Account<'info, TokenAccount>>,
     /// CHECK: Checked by spl_token
     pub mint_authority: AccountInfo<'info>,

--- a/programs/token_faucet/src/lib.rs
+++ b/programs/token_faucet/src/lib.rs
@@ -116,15 +116,15 @@ pub struct FaucetConfig {
 }
 
 #[derive(Accounts)]
-#[instruction(amount: u64, max_amount_mint: u64)]
+#[instruction(amount: u64)]
 pub struct MintToUser<'info> {
     pub faucet_config: Box<Account<'info, FaucetConfig>>,
     #[account(mut)]
     pub mint_account: Box<Account<'info, Mint>>,
     #[account(
         mut,
-        constraint = amount < max_amount_mint,
-        constraint = user_token_account.amount < faucet_config.max_amount_per_user,
+        constraint = amount <= faucet_config.max_amount_mint,
+        constraint = user_token_account.amount + amount <= faucet_config.max_amount_per_user,
     )]
     pub user_token_account: Box<Account<'info, TokenAccount>>,
     /// CHECK: Checked by spl_token

--- a/sdk/src/idl/token_faucet.json
+++ b/sdk/src/idl/token_faucet.json
@@ -48,6 +48,36 @@
       ]
     },
     {
+      "name": "update",
+      "accounts": [
+        {
+          "name": "faucetConfig",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "mintAccount",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "maxAmountMint",
+          "type": "u64"
+        },
+        {
+          "name": "maxAmountPerUser",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "mintToUser",
       "accounts": [
         {
@@ -144,6 +174,10 @@
           {
             "name": "maxAmountPerUser",
             "type": "u64"
+          },
+          {
+            "name": "nonce",
+            "type": "u8"
           }
         ]
       }

--- a/sdk/src/idl/token_faucet.json
+++ b/sdk/src/idl/token_faucet.json
@@ -36,7 +36,16 @@
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "maxAmountMint",
+          "type": "u64"
+        },
+        {
+          "name": "maxAmountPerUser",
+          "type": "u64"
+        }
+      ]
     },
     {
       "name": "mintToUser",
@@ -127,6 +136,14 @@
           {
             "name": "mintAuthorityNonce",
             "type": "u8"
+          },
+          {
+            "name": "maxAmountMint",
+            "type": "u64"
+          },
+          {
+            "name": "maxAmountPerUser",
+            "type": "u64"
           }
         ]
       }

--- a/sdk/src/tokenFaucet.ts
+++ b/sdk/src/tokenFaucet.ts
@@ -71,10 +71,13 @@ export class TokenFaucet {
 		return (await this.getFaucetConfigPublicKeyAndNonce())[0];
 	}
 
-	public async initialize(): Promise<TransactionSignature> {
+	public async initialize(maxAmountMint: number, maxAmountPerUser: number): Promise<TransactionSignature> {
 		const [faucetConfigPublicKey] =
 			await this.getFaucetConfigPublicKeyAndNonce();
-		return await this.program.rpc.initialize({
+		return await this.program.rpc.initialize(
+			new anchor.BN(maxAmountMint),
+			new anchor.BN(maxAmountPerUser),
+			{
 			accounts: {
 				faucetConfig: faucetConfigPublicKey,
 				admin: this.wallet.publicKey,

--- a/sdk/src/tokenFaucet.ts
+++ b/sdk/src/tokenFaucet.ts
@@ -77,20 +77,16 @@ export class TokenFaucet {
 	): Promise<TransactionSignature> {
 		const [faucetConfigPublicKey] =
 			await this.getFaucetConfigPublicKeyAndNonce();
-		return await this.program.rpc.initialize(
-			maxAmountMint,
-			maxAmountPerUser,
-			{
-				accounts: {
-					faucetConfig: faucetConfigPublicKey,
-					admin: this.wallet.publicKey,
-					mintAccount: this.mint,
-					rent: SYSVAR_RENT_PUBKEY,
-					systemProgram: anchor.web3.SystemProgram.programId,
-					tokenProgram: TOKEN_PROGRAM_ID,
-				},
-			}
-		);
+		return await this.program.rpc.initialize(maxAmountMint, maxAmountPerUser, {
+			accounts: {
+				faucetConfig: faucetConfigPublicKey,
+				admin: this.wallet.publicKey,
+				mintAccount: this.mint,
+				rent: SYSVAR_RENT_PUBKEY,
+				systemProgram: anchor.web3.SystemProgram.programId,
+				tokenProgram: TOKEN_PROGRAM_ID,
+			},
+		});
 	}
 
 	public async fetchState(): Promise<any> {

--- a/sdk/src/tokenFaucet.ts
+++ b/sdk/src/tokenFaucet.ts
@@ -89,6 +89,21 @@ export class TokenFaucet {
 		});
 	}
 
+	public async update(
+		maxAmountMint: BN,
+		maxAmountPerUser: BN
+	): Promise<TransactionSignature> {
+		const [faucetConfigPublicKey] =
+			await this.getFaucetConfigPublicKeyAndNonce();
+		return await this.program.rpc.update(maxAmountMint, maxAmountPerUser, {
+			accounts: {
+				faucetConfig: faucetConfigPublicKey,
+				admin: this.wallet.publicKey,
+				mintAccount: this.mint,
+			},
+		}); 
+	}
+
 	public async fetchState(): Promise<any> {
 		return await this.program.account.faucetConfig.fetch(
 			await this.getFaucetConfigPublicKey()

--- a/sdk/src/tokenFaucet.ts
+++ b/sdk/src/tokenFaucet.ts
@@ -71,22 +71,26 @@ export class TokenFaucet {
 		return (await this.getFaucetConfigPublicKeyAndNonce())[0];
 	}
 
-	public async initialize(maxAmountMint: number, maxAmountPerUser: number): Promise<TransactionSignature> {
+	public async initialize(
+		maxAmountMint: number,
+		maxAmountPerUser: number
+	): Promise<TransactionSignature> {
 		const [faucetConfigPublicKey] =
 			await this.getFaucetConfigPublicKeyAndNonce();
 		return await this.program.rpc.initialize(
 			new anchor.BN(maxAmountMint),
 			new anchor.BN(maxAmountPerUser),
 			{
-			accounts: {
-				faucetConfig: faucetConfigPublicKey,
-				admin: this.wallet.publicKey,
-				mintAccount: this.mint,
-				rent: SYSVAR_RENT_PUBKEY,
-				systemProgram: anchor.web3.SystemProgram.programId,
-				tokenProgram: TOKEN_PROGRAM_ID,
-			},
-		});
+				accounts: {
+					faucetConfig: faucetConfigPublicKey,
+					admin: this.wallet.publicKey,
+					mintAccount: this.mint,
+					rent: SYSVAR_RENT_PUBKEY,
+					systemProgram: anchor.web3.SystemProgram.programId,
+					tokenProgram: TOKEN_PROGRAM_ID,
+				},
+			}
+		);
 	}
 
 	public async fetchState(): Promise<any> {

--- a/sdk/src/tokenFaucet.ts
+++ b/sdk/src/tokenFaucet.ts
@@ -72,14 +72,14 @@ export class TokenFaucet {
 	}
 
 	public async initialize(
-		maxAmountMint: number,
-		maxAmountPerUser: number
+		maxAmountMint: BN,
+		maxAmountPerUser: BN
 	): Promise<TransactionSignature> {
 		const [faucetConfigPublicKey] =
 			await this.getFaucetConfigPublicKeyAndNonce();
 		return await this.program.rpc.initialize(
-			new anchor.BN(maxAmountMint),
-			new anchor.BN(maxAmountPerUser),
+			maxAmountMint,
+			maxAmountPerUser,
 			{
 				accounts: {
 					faucetConfig: faucetConfigPublicKey,

--- a/sdk/src/tokenFaucet.ts
+++ b/sdk/src/tokenFaucet.ts
@@ -101,7 +101,7 @@ export class TokenFaucet {
 				admin: this.wallet.publicKey,
 				mintAccount: this.mint,
 			},
-		}); 
+		});
 	}
 
 	public async fetchState(): Promise<any> {

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -55,7 +55,7 @@ describe('token faucet', () => {
 		await clearingHouse.unsubscribe();
 	});
 
-	it('Initialize State', async () => {
+	it('initialize state', async () => {
 		await tokenFaucet.initialize(maxAmountMint, maxAmountPerUser);
 		const state: any = await tokenFaucet.fetchState();
 
@@ -77,6 +77,16 @@ describe('token faucet', () => {
 
 		const mintInfo = await token.getMintInfo();
 		assert.ok(state.mintAuthority.equals(mintInfo.mintAuthority));
+
+		const [_, faucetConfigNonce] = 
+				await PublicKey.findProgramAddress(
+					[
+						Buffer.from(anchor.utils.bytes.utf8.encode("faucet_config")),
+						state.mint.toBuffer()
+					],
+					tokenFaucet.program.programId
+				);
+		assert.ok(faucetConfigNonce === state.nonce)
 	});
 
 	it('mint to user', async () => {
@@ -153,4 +163,16 @@ describe('token faucet', () => {
 		const mintInfo = await token.getMintInfo();
 		assert.ok(provider.wallet.publicKey.equals(mintInfo.mintAuthority));
 	});
+
+
+	it('update state', async () => {
+		const newMaxAmountMint = new BN(100 * 10 ** 6);
+		const newMaxAmountPerUser = new BN(150 * 10 ** 6);
+		await tokenFaucet.update(newMaxAmountMint, newMaxAmountPerUser)
+		const state: any = await tokenFaucet.fetchState()
+		assert.ok(state.maxAmountMint.eq(newMaxAmountMint))
+		assert.ok(state.maxAmountPerUser.eq(newMaxAmountPerUser))
+	})
+
+
 });

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -54,9 +54,9 @@ describe('token faucet', () => {
 	});
 
 	it('Initialize State', async () => {
-		const usdcPrecision: number = (await token.getMintInfo()).decimals
-		const maxAmountMint: number = 10_000 * Math.pow(10, usdcPrecision)
-		const maxAmountPerUser: number = 10_000_000 * Math.pow(10, usdcPrecision)
+		const usdcPrecision: number = (await token.getMintInfo()).decimals;
+		const maxAmountMint: number = 10_000 * Math.pow(10, usdcPrecision);
+		const maxAmountPerUser: number = 10_000_000 * Math.pow(10, usdcPrecision);
 		await tokenFaucet.initialize(maxAmountMint, maxAmountPerUser);
 		const state: any = await tokenFaucet.fetchState();
 

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -54,7 +54,10 @@ describe('token faucet', () => {
 	});
 
 	it('Initialize State', async () => {
-		await tokenFaucet.initialize();
+		const usdcPrecision: number = (await token.getMintInfo()).decimals
+		const maxAmountMint: number = 10_000 * Math.pow(10, usdcPrecision)
+		const maxAmountPerUser: number = 10_000_000 * Math.pow(10, usdcPrecision)
+		await tokenFaucet.initialize(maxAmountMint, maxAmountPerUser);
 		const state: any = await tokenFaucet.fetchState();
 
 		assert.ok(state.admin.equals(provider.wallet.publicKey));

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -55,8 +55,8 @@ describe('token faucet', () => {
 
 	it('Initialize State', async () => {
 		const usdcPrecision: number = (await token.getMintInfo()).decimals;
-		const maxAmountMint: number = 10_000 * Math.pow(10, usdcPrecision);
-		const maxAmountPerUser: number = 10_000_000 * Math.pow(10, usdcPrecision);
+		const maxAmountMint: BN = new BN(10_000 * Math.pow(10, usdcPrecision));
+		const maxAmountPerUser: BN = new BN(10_000_000 * Math.pow(10, usdcPrecision));
 		await tokenFaucet.initialize(maxAmountMint, maxAmountPerUser);
 		const state: any = await tokenFaucet.fetchState();
 

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -78,15 +78,14 @@ describe('token faucet', () => {
 		const mintInfo = await token.getMintInfo();
 		assert.ok(state.mintAuthority.equals(mintInfo.mintAuthority));
 
-		const [_, faucetConfigNonce] = 
-				await PublicKey.findProgramAddress(
-					[
-						Buffer.from(anchor.utils.bytes.utf8.encode("faucet_config")),
-						state.mint.toBuffer()
-					],
-					tokenFaucet.program.programId
-				);
-		assert.ok(faucetConfigNonce === state.nonce)
+		const [_, faucetConfigNonce] = await PublicKey.findProgramAddress(
+			[
+				Buffer.from(anchor.utils.bytes.utf8.encode('faucet_config')),
+				state.mint.toBuffer(),
+			],
+			tokenFaucet.program.programId
+		);
+		assert.ok(faucetConfigNonce === state.nonce);
 	});
 
 	it('mint to user', async () => {
@@ -164,15 +163,12 @@ describe('token faucet', () => {
 		assert.ok(provider.wallet.publicKey.equals(mintInfo.mintAuthority));
 	});
 
-
 	it('update state', async () => {
 		const newMaxAmountMint = new BN(100 * 10 ** 6);
 		const newMaxAmountPerUser = new BN(150 * 10 ** 6);
-		await tokenFaucet.update(newMaxAmountMint, newMaxAmountPerUser)
-		const state: any = await tokenFaucet.fetchState()
-		assert.ok(state.maxAmountMint.eq(newMaxAmountMint))
-		assert.ok(state.maxAmountPerUser.eq(newMaxAmountPerUser))
-	})
-
-
+		await tokenFaucet.update(newMaxAmountMint, newMaxAmountPerUser);
+		const state: any = await tokenFaucet.fetchState();
+		assert.ok(state.maxAmountMint.eq(newMaxAmountMint));
+		assert.ok(state.maxAmountPerUser.eq(newMaxAmountPerUser));
+	});
 });

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -96,18 +96,21 @@ describe('token faucet', () => {
 	});
 
 	it('cannot mint above maxAmountMint to user', async () => {
-		const keyPair = new Keypair()
+		const keyPair = new Keypair();
 		let userTokenAccountInfo = await token.getOrCreateAssociatedAccountInfo(
 			keyPair.publicKey
 		);
 		try {
-			await tokenFaucet.mintToUser(userTokenAccountInfo.address, amount.add(new BN(1)));
+			await tokenFaucet.mintToUser(
+				userTokenAccountInfo.address,
+				amount.add(new BN(1))
+			);
 		} catch (e) {}
 		userTokenAccountInfo = await token.getOrCreateAssociatedAccountInfo(
 			keyPair.publicKey
 		);
-		assert.ok(userTokenAccountInfo.amount.eq(new BN(0)))
-	})
+		assert.ok(userTokenAccountInfo.amount.eq(new BN(0)));
+	});
 
 	it('cannot mint more than maxAmountPerUser to user', async () => {
 		const keyPair = new Keypair();
@@ -121,12 +124,12 @@ describe('token faucet', () => {
 		}
 		try {
 			await tokenFaucet.mintToUser(userTokenAccountInfo.address, amount);
-		} catch(e) {}
+		} catch (e) {}
 		userTokenAccountInfo = await token.getOrCreateAssociatedAccountInfo(
 			keyPair.publicKey
 		);
 		assert.ok(userTokenAccountInfo.amount.eq(amount));
-	})
+	});
 
 	it('initialize user for dev net', async () => {
 		const state: any = await tokenFaucet.fetchState();

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -134,7 +134,7 @@ describe('token faucet', () => {
 		await clearingHouse.initialize(state.mint, false);
 		await clearingHouse.subscribe();
 		await initializeQuoteAssetBank(clearingHouse, usdcMint.publicKey);
-		const [txSig, userAccountPublicKey] = await clearingHouse.initializeUserAccountForDevnet(
+		await clearingHouse.initializeUserAccountForDevnet(
 			0,
 			'crisp',
 			new BN(0),

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -112,7 +112,7 @@ describe('token faucet', () => {
 		assert.ok(userTokenAccountInfo.amount.eq(new BN(0)));
 	});
 
-	it('cannot mint more than maxAmountPerUser to user', async () => {
+	it('user cannot mint if they have more than maxAmountPerUser', async () => {
 		const keyPair = new Keypair();
 		let userTokenAccountInfo = await token.getOrCreateAssociatedAccountInfo(
 			keyPair.publicKey

--- a/tests/tokenFaucet.ts
+++ b/tests/tokenFaucet.ts
@@ -95,7 +95,7 @@ describe('token faucet', () => {
 		assert.ok(userTokenAccountInfo.amount.eq(amount));
 	});
 
-	it('mints above maxAmountMint to user', async () => {
+	it('cannot mint above maxAmountMint to user', async () => {
 		const keyPair = new Keypair()
 		let userTokenAccountInfo = await token.getOrCreateAssociatedAccountInfo(
 			keyPair.publicKey
@@ -109,7 +109,7 @@ describe('token faucet', () => {
 		assert.ok(userTokenAccountInfo.amount.eq(new BN(0)))
 	})
 
-	it('mints more than maxAmountPerUser to user', async () => {
+	it('cannot mint more than maxAmountPerUser to user', async () => {
 		const keyPair = new Keypair();
 		let userTokenAccountInfo = await token.getOrCreateAssociatedAccountInfo(
 			keyPair.publicKey


### PR DESCRIPTION
**Chore: Devnet**

This change will make it harder for someone to have an unrealistic amount of tokens and thus reduce weirdness in Devnet testing of a whale owning the majority of the USDC supply (therefore becoming the market and probably distorting analysis/analytics of Devnet results).

**Added:**
1) constraint to the number of tokens that you can mint from the USDC faucet for mintTo ix.
2) constraint to the number of tokens that a single token account can hold for mintTo ix.
3) an `update` ix, in case the admin wants to change the limits on the fly / ephemerally mint more tokens to someone.
4) the necessary changes to the SDK for the TokenFaucet obj. 
5) the necessary changes and constraint tests to ./tests/tokenFaucet.ts

**Program**
The TokenFaucet program already has a config account. So we add two more vars to the account:
1) `max_amount_mint` - the max amount of tokens that can be minted per mint_to_user ix call.
2) `max_amount_per_user` - the max amount of tokens that a user's token account can hold before addition ix calls fail.

These vars are passed in as args on the `initialize` ix call. 

**Ran**
1) ts-mocha -t 1000000 ./tests/tokenFaucet.ts All tests have passed.

**Did Not**
Since this is a tiny change I did not:
1) bump SDK. 
2) generate-docs (the diff would be too large)

**TODO**
1) I did not find the script that you guys use to `new TokenFaucet(...)` for the devnet trials. I don't think it's in this repo.
2) Add commander commands to make it easier to manage faucet. 

**Notes**
* People can of course game this very easily w/ multiple kps. But they will have to dig into the code.
* Chose to create an `update` ix instead of adding a pubkey constraint to the `mintTo` ix because the `mintTo` ix has no signer. I would have rathered the signer pubkey constraint approach but didn't want to touch the idl of the `mintTo` function since its already hooked up to FE. We can go that way though, it's cleaner but we lose on the fly updates. So LMK. We'd would have to add a signer to `mintTo` and pass it into the frontend, then apply `max_amount_mint` and `max_amount_per_user` iff the signer is not faucet admin. 

