### PR TITLE
19/lp baa fix

### DIFF
--- a/programs/clearing_house/src/controller/position.rs
+++ b/programs/clearing_house/src/controller/position.rs
@@ -430,6 +430,7 @@ pub fn update_amm_and_lp_market_position(
             AMM_RESERVE_PRECISION,
             total_lp_shares,
         )?;
+
         let per_lp_delta_quote = get_proportion_i128(
             delta.quote_asset_amount,
             AMM_RESERVE_PRECISION,

--- a/programs/clearing_house/src/controller/position.rs
+++ b/programs/clearing_house/src/controller/position.rs
@@ -442,6 +442,17 @@ pub fn update_amm_and_lp_market_position(
         let lp_delta_quote =
             get_proportion_i128(per_lp_delta_quote, user_lp_shares, AMM_RESERVE_PRECISION)?;
 
+        // account for round off errors
+        let per_lp_delta_base =
+            get_proportion_i128(lp_delta_base, AMM_RESERVE_PRECISION, user_lp_shares)?;
+        let per_lp_delta_quote =
+            get_proportion_i128(lp_delta_quote, AMM_RESERVE_PRECISION, user_lp_shares)?;
+        
+        let lp_delta_base =
+            get_proportion_i128(per_lp_delta_base, user_lp_shares, AMM_RESERVE_PRECISION)?;
+        let lp_delta_quote =
+            get_proportion_i128(per_lp_delta_quote, user_lp_shares, AMM_RESERVE_PRECISION)?;
+
         let per_lp_position_delta = PositionDelta {
             base_asset_amount: -per_lp_delta_base,
             quote_asset_amount: -per_lp_delta_quote,

--- a/programs/clearing_house/src/controller/position.rs
+++ b/programs/clearing_house/src/controller/position.rs
@@ -421,28 +421,29 @@ pub fn update_amm_and_lp_market_position(
     fee_to_market: i128,
 ) -> ClearingHouseResult {
     let total_lp_shares = market.amm.sqrt_k;
-    let non_amm_lp_shares = market.amm.user_lp_shares;
+    let user_lp_shares = market.amm.user_lp_shares;
 
-    let (lp_delta_base, lp_delta_quote, lp_fee) = if non_amm_lp_shares > 0 {
+    let (lp_delta_base, lp_delta_quote, lp_fee) = if user_lp_shares > 0 {
         // update Market per lp position
-        let lp_delta_base =
-            get_proportion_i128(delta.base_asset_amount, non_amm_lp_shares, total_lp_shares)?;
-        let lp_delta_quote =
-            get_proportion_i128(delta.quote_asset_amount, non_amm_lp_shares, total_lp_shares)?;
-
-        let per_lp_delta_base = -get_proportion_i128(
+        let per_lp_delta_base = get_proportion_i128(
             delta.base_asset_amount,
             AMM_RESERVE_PRECISION,
             total_lp_shares,
         )?;
-        let per_lp_delta_quote = -get_proportion_i128(
+        let per_lp_delta_quote = get_proportion_i128(
             delta.quote_asset_amount,
             AMM_RESERVE_PRECISION,
             total_lp_shares,
         )?;
+
+        let lp_delta_base =
+            get_proportion_i128(per_lp_delta_base, user_lp_shares, AMM_RESERVE_PRECISION)?;
+        let lp_delta_quote =
+            get_proportion_i128(per_lp_delta_quote, user_lp_shares, AMM_RESERVE_PRECISION)?;
+
         let per_lp_position_delta = PositionDelta {
-            base_asset_amount: per_lp_delta_base,
-            quote_asset_amount: per_lp_delta_quote,
+            base_asset_amount: -per_lp_delta_base,
+            quote_asset_amount: -per_lp_delta_quote,
         };
 
         update_amm_position(market, &per_lp_position_delta, true)?;
@@ -450,7 +451,7 @@ pub fn update_amm_and_lp_market_position(
         // 1/5 of fee auto goes to market
         // the rest goes to lps/market proportional
         let lp_fee = (fee_to_market - (fee_to_market / 5)) // todo: 80% retained
-            .checked_mul(cast_to_i128(non_amm_lp_shares)?)
+            .checked_mul(cast_to_i128(user_lp_shares)?)
             .ok_or_else(math_error!())?
             .checked_div(cast_to_i128(total_lp_shares)?)
             .ok_or_else(math_error!())?;
@@ -459,7 +460,7 @@ pub fn update_amm_and_lp_market_position(
             lp_fee
                 .checked_mul(AMM_RESERVE_PRECISION_I128)
                 .ok_or_else(math_error!())?
-                .checked_div(cast_to_i128(market.amm.user_lp_shares)?)
+                .checked_div(cast_to_i128(user_lp_shares)?)
                 .ok_or_else(math_error!())?
         } else {
             0

--- a/programs/clearing_house/src/math/amm.rs
+++ b/programs/clearing_house/src/math/amm.rs
@@ -1841,7 +1841,7 @@ mod test {
 
         assert_eq!(position.base_asset_amount, 0);
         assert_eq!(position.quote_asset_amount, -QUOTE_PRECISION_I128);
-        assert_eq!(position.last_net_base_asset_amount_per_lp, 0);
+        assert_eq!(position.last_net_base_asset_amount_per_lp, 1);
         assert_eq!(
             position.last_net_quote_asset_amount_per_lp,
             -QUOTE_PRECISION_I128
@@ -1897,7 +1897,7 @@ mod test {
         let cost = adjust_k_cost(&mut market, &update_k_up).unwrap();
         assert_eq!(
             market.amm.net_base_asset_amount,
-            (AMM_RESERVE_PRECISION / 10) as i128 - 2
+            (AMM_RESERVE_PRECISION / 10) as i128 - 1 // burned the 
         );
         assert_eq!(cost, 49406); //0.05
 
@@ -1914,7 +1914,7 @@ mod test {
         let cost = adjust_k_cost(&mut market, &update_k_up).unwrap();
         assert_eq!(
             market.amm.net_base_asset_amount,
-            (AMM_RESERVE_PRECISION / 10) as i128 - 2
+            (AMM_RESERVE_PRECISION / 10) as i128 - 1
         );
         assert_eq!(cost, 187807); //0.19
 

--- a/programs/clearing_house/src/math/amm.rs
+++ b/programs/clearing_house/src/math/amm.rs
@@ -1826,7 +1826,7 @@ mod test {
             ..MarketPosition::default()
         };
 
-        mint_lp_shares(&mut position, &mut market, AMM_RESERVE_PRECISION, 0).unwrap();
+        mint_lp_shares(&mut position, &mut market, AMM_RESERVE_PRECISION, 0, 0).unwrap();
 
         market.amm.market_position_per_lp = MarketPosition {
             base_asset_amount: 1,
@@ -1837,7 +1837,7 @@ mod test {
         let mark_price = market.amm.mark_price().unwrap();
         update_spreads(&mut market.amm, mark_price).unwrap();
 
-        settle_lp_position(&mut position, &mut market).unwrap();
+        settle_lp_position(&mut position, &mut market, 1).unwrap();
 
         assert_eq!(position.base_asset_amount, 0);
         assert_eq!(position.quote_asset_amount, -QUOTE_PRECISION_I128);
@@ -1868,7 +1868,7 @@ mod test {
 
         // lp whale adds
         let lp_whale_amount = 1000 * AMM_RESERVE_PRECISION;
-        mint_lp_shares(&mut position, &mut market, lp_whale_amount, 0).unwrap();
+        mint_lp_shares(&mut position, &mut market, lp_whale_amount, 0, 0).unwrap();
 
         // ensure same cost
         let update_k_up =
@@ -1897,7 +1897,7 @@ mod test {
         let cost = adjust_k_cost(&mut market, &update_k_up).unwrap();
         assert_eq!(
             market.amm.net_base_asset_amount,
-            (AMM_RESERVE_PRECISION / 10) as i128
+            (AMM_RESERVE_PRECISION / 10) as i128 - 2
         );
         assert_eq!(cost, 49406); //0.05
 
@@ -1914,7 +1914,7 @@ mod test {
         let cost = adjust_k_cost(&mut market, &update_k_up).unwrap();
         assert_eq!(
             market.amm.net_base_asset_amount,
-            (AMM_RESERVE_PRECISION / 10) as i128
+            (AMM_RESERVE_PRECISION / 10) as i128 - 2
         );
         assert_eq!(cost, 187807); //0.19
 

--- a/programs/clearing_house/src/math/lp.rs
+++ b/programs/clearing_house/src/math/lp.rs
@@ -30,18 +30,6 @@ pub fn calculate_settle_lp_metrics(
             amm.base_asset_amount_step_size,
         )?;
 
-    // note: since pnl may go into the qaa of a position its not really fair to ensure qaa >= min_qaa
-    let min_baa = amm.base_asset_amount_step_size;
-    let remainder_base_asset_amount = if standardized_base_asset_amount.unsigned_abs() >= min_baa {
-        remainder_base_asset_amount
-    } else {
-        base_asset_amount
-    };
-
-    let standardized_base_asset_amount = base_asset_amount
-        .checked_sub(remainder_base_asset_amount)
-        .ok_or_else(math_error!())?;
-
     let lp_metrics = LPMetrics {
         base_asset_amount: standardized_base_asset_amount,
         quote_asset_amount,

--- a/programs/clearing_house/src/math/lp.rs
+++ b/programs/clearing_house/src/math/lp.rs
@@ -30,9 +30,8 @@ pub fn calculate_settle_lp_metrics(
             amm.base_asset_amount_step_size,
         )?;
 
-    let min_baa = amm.base_asset_amount_step_size;
-
     // note: since pnl may go into the qaa of a position its not really fair to ensure qaa >= min_qaa
+    let min_baa = amm.base_asset_amount_step_size;
     let remainder_base_asset_amount = if standardized_base_asset_amount.unsigned_abs() >= min_baa {
         remainder_base_asset_amount
     } else {

--- a/programs/clearing_house/src/state/user.rs
+++ b/programs/clearing_house/src/state/user.rs
@@ -194,6 +194,7 @@ pub struct MarketPosition {
 
     // lp stuff
     pub lp_shares: u128,
+    pub remainder_base_asset_amount: i128,
     pub last_net_base_asset_amount_per_lp: i128,
     pub last_net_quote_asset_amount_per_lp: i128,
     pub last_lp_add_time: i64,


### PR DESCRIPTION
- prev impl lead to unsettled baa != 0 when user_lp_shares == 0 

major fixes in this branch include how we track remainder baa for the lp **ctrl/lp.rs**
```rust
    position.remainder_base_asset_amount = position.remainder_base_asset_amount
        .checked_add(lp_metrics.remainder_base_asset_amount)
        .ok_or_else(math_error!())?;
    
    if position.remainder_base_asset_amount.unsigned_abs() >= market.amm.base_asset_amount_step_size {
        let (standardized_remainder_base_asset_amount, remainder_base_asset_amount) =
            crate::math::orders::standardize_base_asset_amount_with_remainder_i128(
                position.remainder_base_asset_amount,
                market.amm.base_asset_amount_step_size,
            )?;

        lp_metrics.base_asset_amount = lp_metrics.base_asset_amount
            .checked_add(standardized_remainder_base_asset_amount)
            .ok_or_else(math_error!())?;
        
        position.remainder_base_asset_amount = remainder_base_asset_amount;
    }
```

as well as how we compute the per_lp base asset amount (we do it twice to reduce rounding errors) in **ctrl/position.rs**
```rust
        // update Market per lp position
        let per_lp_delta_base = get_proportion_i128(
            delta.base_asset_amount,
            AMM_RESERVE_PRECISION,
            total_lp_shares,
        )?;

        let per_lp_delta_quote = get_proportion_i128(
            delta.quote_asset_amount,
            AMM_RESERVE_PRECISION,
            total_lp_shares,
        )?;

        let lp_delta_base =
            get_proportion_i128(per_lp_delta_base, user_lp_shares, AMM_RESERVE_PRECISION)?;
        let lp_delta_quote =
            get_proportion_i128(per_lp_delta_quote, user_lp_shares, AMM_RESERVE_PRECISION)?;

        // account for round off errors
        let per_lp_delta_base =
            get_proportion_i128(lp_delta_base, AMM_RESERVE_PRECISION, user_lp_shares)?;
        let per_lp_delta_quote =
            get_proportion_i128(lp_delta_quote, AMM_RESERVE_PRECISION, user_lp_shares)?;
        
        let lp_delta_base =
            get_proportion_i128(per_lp_delta_base, user_lp_shares, AMM_RESERVE_PRECISION)?;
        let lp_delta_quote =
            get_proportion_i128(per_lp_delta_quote, user_lp_shares, AMM_RESERVE_PRECISION)?;
```

back testing the protocol against random long/short mint/burn events the delta between the sum of all lps and the actual unsettled baa is ~3 using the code below 

```python
market = await get_market_account(program, 0)

for user in clearing_house_users:
    position = user.positions[0]    
    if position.lp_shares > 0: 
        delta_baa_per_lp = market.amm.market_position_per_lp.base_asset_amount - position.last_net_base_asset_amount_per_lp
        baa = delta_baa_per_lp * position.lp_shares / AMM_RESERVE_PRECISION
        unsettled_baa += baa 

print(unsettled_baa, market.amm.net_unsettled_lp_base_asset_amount) # delta ~3
```
