### PR TITLE
update bid/ask reserves in update k 

### DIFF
--- a/programs/clearing_house/src/math/amm.rs
+++ b/programs/clearing_house/src/math/amm.rs
@@ -2642,8 +2642,6 @@ mod test {
             },
             ..PerpMarket::default()
         };
-        // market.amm.base_spread
-
         // increase k by .25%
         let update_k_up =
             get_update_k_result(&market, bn::U192::from(501 * AMM_RESERVE_PRECISION), true)

--- a/programs/clearing_house/src/math/amm.rs
+++ b/programs/clearing_house/src/math/amm.rs
@@ -1397,6 +1397,9 @@ pub fn update_k(market: &mut PerpMarket, update_k_result: &UpdateKResult) -> Cle
     market.amm.min_base_asset_reserve = min_base_asset_reserve;
     market.amm.max_base_asset_reserve = max_base_asset_reserve;
 
+    let mark_price_after = market.amm.mark_price()?;
+    crate::controller::amm::update_spreads(&mut market.amm, mark_price_after)?;
+
     Ok(())
 }
 
@@ -2565,6 +2568,67 @@ mod test {
     }
 
     #[test]
+    fn calculate_k_tests_with_spread() {
+        let mut market = PerpMarket {
+            amm: AMM {
+                base_asset_reserve: 5122950819670000,
+                quote_asset_reserve: 488 * AMM_RESERVE_PRECISION,
+                concentration_coef: MAX_CONCENTRATION_COEFFICIENT,
+                sqrt_k: 500 * AMM_RESERVE_PRECISION,
+                peg_multiplier: 50000,
+                net_base_asset_amount: -122950819670000,
+                ..AMM::default()
+            },
+            ..PerpMarket::default()
+        };
+        market.amm.max_base_asset_reserve = u128::MAX;
+        market.amm.min_base_asset_reserve = 0;
+        market.amm.base_spread = 10;
+        market.amm.long_spread = 5;
+        market.amm.short_spread = 5;
+
+        let (new_ask_base_asset_reserve, new_ask_quote_asset_reserve) =
+            crate::amm::calculate_spread_reserves(&market.amm, PositionDirection::Long).unwrap();
+        let (new_bid_base_asset_reserve, new_bid_quote_asset_reserve) =
+            crate::amm::calculate_spread_reserves(&market.amm, PositionDirection::Short).unwrap();
+
+        market.amm.ask_base_asset_reserve = new_ask_base_asset_reserve;
+        market.amm.bid_base_asset_reserve = new_bid_base_asset_reserve;
+        market.amm.ask_quote_asset_reserve = new_ask_quote_asset_reserve;
+        market.amm.bid_quote_asset_reserve = new_bid_quote_asset_reserve;
+
+        validate!(
+            market.amm.bid_base_asset_reserve >= market.amm.base_asset_reserve
+                && market.amm.bid_quote_asset_reserve <= market.amm.quote_asset_reserve,
+            ErrorCode::DefaultError,
+            "bid reserves out of wack: {} -> {}, quote: {} -> {}",
+            market.amm.bid_base_asset_reserve,
+            market.amm.base_asset_reserve,
+            market.amm.bid_quote_asset_reserve,
+            market.amm.quote_asset_reserve
+        )
+        .unwrap();
+
+        // increase k by .25%
+        let update_k_result =
+            get_update_k_result(&market, bn::U192::from(501 * AMM_RESERVE_PRECISION), true)
+                .unwrap();
+        update_k(&mut market, &update_k_result).unwrap();
+
+        validate!(
+            market.amm.bid_base_asset_reserve >= market.amm.base_asset_reserve
+                && market.amm.bid_quote_asset_reserve <= market.amm.quote_asset_reserve,
+            ErrorCode::DefaultError,
+            "bid reserves out of wack: {} -> {}, quote: {} -> {}",
+            market.amm.bid_base_asset_reserve,
+            market.amm.base_asset_reserve,
+            market.amm.bid_quote_asset_reserve,
+            market.amm.quote_asset_reserve
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn calculate_k_tests() {
         let mut market = PerpMarket {
             amm: AMM {
@@ -2578,6 +2642,8 @@ mod test {
             },
             ..PerpMarket::default()
         };
+        // market.amm.base_spread
+
         // increase k by .25%
         let update_k_up =
             get_update_k_result(&market, bn::U192::from(501 * AMM_RESERVE_PRECISION), true)


### PR DESCRIPTION
current impl leads to bid/ask being out of whack (validate.rs) when an lp adds shares and adjusts k + base reserves

soln: update bid/ask reserves too in update k 

