### PR TITLE
19/improve-lp-settle

### DIFF
--- a/programs/clearing_house/src/controller/lp.rs
+++ b/programs/clearing_house/src/controller/lp.rs
@@ -146,10 +146,10 @@ pub fn settle_lp(
     Ok(())
 }
 
-// note: must settle funding before settling the lp bc 
-// settling the lp can take on a new position which requires funding 
+// note: must settle funding before settling the lp bc
+// settling the lp can take on a new position which requires funding
 // to be up-to-date
-pub fn settle_lp_and_funding_payment(
+pub fn settle_funding_payment_then_lp(
     user: &mut User,
     user_key: &Pubkey,
     market: &mut PerpMarket,

--- a/programs/clearing_house/src/controller/lp.rs
+++ b/programs/clearing_house/src/controller/lp.rs
@@ -1,4 +1,3 @@
-use crate::controller::position::get_position_index;
 use crate::error::{ClearingHouseResult, ErrorCode};
 use crate::math_error;
 use crate::state::market::PerpMarket;
@@ -126,9 +125,8 @@ pub fn settle_lp(
     user_key: &Pubkey,
     market: &mut PerpMarket,
     now: i64,
-) -> ClearingHouseResult<()> {
-    if let Ok(position_index) = get_position_index(&user.perp_positions, market.market_index) {
-        let position = &mut user.perp_positions[position_index];
+) -> ClearingHouseResult {
+    if let Ok(position) = user.get_perp_position_mut(market.market_index) {
         if position.lp_shares > 0 {
             let (position_delta, pnl) = settle_lp_position(position, market)?;
 
@@ -143,8 +141,19 @@ pub fn settle_lp(
                 n_shares: 0
             });
         }
-    };
+    }
+
     Ok(())
+}
+
+pub fn settle_lp_and_funding_payment(
+    user: &mut User,
+    user_key: &Pubkey,
+    market: &mut PerpMarket,
+    now: i64,
+) -> ClearingHouseResult {
+    crate::controller::funding::settle_funding_payment(user, user_key, market, now)?;
+    settle_lp(user, user_key, market, now)
 }
 
 pub fn burn_lp_shares(
@@ -153,10 +162,6 @@ pub fn burn_lp_shares(
     shares_to_burn: u64,
     oracle_price: i128,
 ) -> ClearingHouseResult<(PositionDelta, i64)> {
-    if shares_to_burn == 0 {
-        return Ok((PositionDelta::default(), 0));
-    }
-
     // settle
     let (position_delta, pnl) = settle_lp_position(position, market)?;
 

--- a/programs/clearing_house/src/controller/lp.rs
+++ b/programs/clearing_house/src/controller/lp.rs
@@ -146,6 +146,9 @@ pub fn settle_lp(
     Ok(())
 }
 
+// note: must settle funding before settling the lp bc 
+// settling the lp can take on a new position which requires funding 
+// to be up-to-date
 pub fn settle_lp_and_funding_payment(
     user: &mut User,
     user_key: &Pubkey,

--- a/programs/clearing_house/src/controller/orders.rs
+++ b/programs/clearing_house/src/controller/orders.rs
@@ -515,9 +515,7 @@ pub fn fill_order(
 
     // settle lp position so its tradeable
     let mut market = perp_market_map.get_ref_mut(&market_index)?;
-
-    controller::funding::settle_funding_payment(user, &user_key, &mut market, now)?;
-    controller::lp::settle_lp(user, &user_key, &mut market, now)?;
+    controller::lp::settle_lp_and_funding_payment(user, &user_key, &mut market, now)?;
 
     validate!(
         matches!(

--- a/programs/clearing_house/src/controller/orders.rs
+++ b/programs/clearing_house/src/controller/orders.rs
@@ -515,7 +515,7 @@ pub fn fill_order(
 
     // settle lp position so its tradeable
     let mut market = perp_market_map.get_ref_mut(&market_index)?;
-    controller::lp::settle_lp_and_funding_payment(user, &user_key, &mut market, now)?;
+    controller::lp::settle_funding_payment_then_lp(user, &user_key, &mut market, now)?;
 
     validate!(
         matches!(

--- a/programs/clearing_house/src/controller/pnl.rs
+++ b/programs/clearing_house/src/controller/pnl.rs
@@ -58,8 +58,7 @@ pub fn settle_pnl(
 
     validate_market_within_price_band(&market, state, true, None)?;
 
-    settle_funding_payment(user, user_key, &mut market, now)?;
-    crate::controller::lp::settle_lp(user, user_key, &mut market, now)?;
+    crate::controller::lp::settle_lp_and_funding_payment(user, user_key, &mut market, now)?;
 
     drop(market);
 

--- a/programs/clearing_house/src/controller/pnl.rs
+++ b/programs/clearing_house/src/controller/pnl.rs
@@ -58,7 +58,7 @@ pub fn settle_pnl(
 
     validate_market_within_price_band(&market, state, true, None)?;
 
-    crate::controller::lp::settle_lp_and_funding_payment(user, user_key, &mut market, now)?;
+    crate::controller::lp::settle_funding_payment_then_lp(user, user_key, &mut market, now)?;
 
     drop(market);
 

--- a/programs/clearing_house/src/lib.rs
+++ b/programs/clearing_house/src/lib.rs
@@ -1045,7 +1045,7 @@ pub mod clearing_house {
             PerpMarketMap::load(&get_market_set(market_index), remaining_accounts_iter)?;
 
         let market = &mut market_map.get_ref_mut(&market_index)?;
-        controller::lp::settle_lp_and_funding_payment(user, &user_key, market, now)?;
+        controller::lp::settle_funding_payment_then_lp(user, &user_key, market, now)?;
 
         Ok(())
     }

--- a/programs/clearing_house/src/lib.rs
+++ b/programs/clearing_house/src/lib.rs
@@ -44,7 +44,6 @@ pub mod clearing_house {
     use std::option::Option::Some;
 
     use crate::controller::lp::burn_lp_shares;
-    use crate::controller::position::get_position_index;
     use crate::controller::validate::validate_market_account;
     use crate::math;
     use crate::math::casting::{cast, cast_to_i128, cast_to_u128, cast_to_u32, Cast};
@@ -1046,10 +1045,7 @@ pub mod clearing_house {
             PerpMarketMap::load(&get_market_set(market_index), remaining_accounts_iter)?;
 
         let market = &mut market_map.get_ref_mut(&market_index)?;
-
-        controller::funding::settle_funding_payment(user, &user_key, market, now)?;
-
-        controller::lp::settle_lp(user, &user_key, market, now)?;
+        controller::lp::settle_lp_and_funding_payment(user, &user_key, market, now)?;
 
         Ok(())
     }
@@ -1079,10 +1075,6 @@ pub mod clearing_house {
         let _spot_market_map = SpotMarketMap::load(&SpotMarketSet::new(), remaining_accounts_iter)?;
         let market_map =
             PerpMarketMap::load(&get_market_set(market_index), remaining_accounts_iter)?;
-        {
-            let mut market = market_map.get_ref_mut(&market_index)?;
-            controller::funding::settle_funding_payment(user, &user_key, &mut market, now)?;
-        }
 
         // standardize n shares to burn
         let shares_to_burn: u64 = {
@@ -1109,15 +1101,17 @@ pub mod clearing_house {
             ErrorCode::TryingToRemoveLiquidityTooFast
         )?;
 
-        let position_index = get_position_index(&user.perp_positions, market_index)?;
-        let position = &mut user.perp_positions[position_index];
+        crate::controller::funding::settle_funding_payment(user, &user_key, &mut market, now)?;
+
+        let oracle_price = oracle_map.get_price_data(&market.amm.oracle)?.price;
+
+        let position = user.get_perp_position_mut(market_index)?;
 
         validate!(
             position.lp_shares >= shares_to_burn,
             ErrorCode::InsufficientLPTokens
         )?;
 
-        let oracle_price = oracle_map.get_price_data(&market.amm.oracle)?.price;
         let (position_delta, pnl) =
             burn_lp_shares(position, &mut market, shares_to_burn, oracle_price)?;
 
@@ -1156,26 +1150,8 @@ pub mod clearing_house {
             Some(state.oracle_guard_rails),
         )?;
         let spot_market_map = SpotMarketMap::load(&SpotMarketSet::new(), remaining_accounts_iter)?;
-
         let market_map =
             PerpMarketMap::load(&get_market_set(market_index), remaining_accounts_iter)?;
-
-        {
-            let mut market = market_map.get_ref_mut(&market_index)?;
-            controller::funding::settle_funding_payment(user, &user_key, &mut market, now)?;
-
-            validate!(
-                matches!(
-                    market.status,
-                    MarketStatus::Active
-                        | MarketStatus::FundingPaused
-                        | MarketStatus::FillPaused
-                        | MarketStatus::WithdrawPaused
-                ),
-                ErrorCode::DefaultError,
-                "Market Status doesn't allow for new LP liquidity"
-            )?;
-        }
 
         validate!(!user.bankrupt, ErrorCode::UserBankrupt)?;
         math::liquidation::validate_user_not_being_liquidated(
@@ -1188,6 +1164,18 @@ pub mod clearing_house {
 
         {
             let mut market = market_map.get_ref_mut(&market_index)?;
+
+            validate!(
+                matches!(
+                    market.status,
+                    MarketStatus::Active
+                        | MarketStatus::FundingPaused
+                        | MarketStatus::FillPaused
+                        | MarketStatus::WithdrawPaused
+                ),
+                ErrorCode::DefaultError,
+                "Market Status doesn't allow for new LP liquidity"
+            )?;
 
             validate!(
                 n_shares >= market.amm.base_asset_amount_step_size,
@@ -1203,6 +1191,8 @@ pub mod clearing_house {
                 market.amm.base_asset_amount_step_size,
             )?
             .cast::<u64>()?;
+
+            crate::controller::funding::settle_funding_payment(user, &user_key, &mut market, now)?;
 
             controller::lp::mint_lp_shares(
                 user.force_get_perp_position_mut(market_index)?,


### PR DESCRIPTION
- add function called settle_user_funding_payment_and_lp so funding is always settled when lp is settled
- update getting perp positions using the user method instead of old get_index=>user.perp[index]

note: mint/burn dont call the new settling funding+lp fcn bc it gets pretty messy passing around a user struct (required by settle_funding) + a position 