### PR TITLE
high-util-neg-pnl-settles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- program: block negative pnl settles which would lead to more borrows when quote spot utilization is high ([#273](https://github.com/drift-labs/protocol-v2/pull/273)).
+
 ### Fixes
 
 ### Breaking

--- a/programs/drift/src/controller/amm.rs
+++ b/programs/drift/src/controller/amm.rs
@@ -543,14 +543,14 @@ pub fn update_pool_balances(
     let pnl_to_settle_with_user = if user_unsettled_pnl > 0 {
         min(user_unsettled_pnl, pnl_pool_token_amount.cast::<i128>()?)
     } else {
-        let token_amount = get_signed_token_amount(
-            get_token_amount(
-                user_quote_position.balance(),
-                spot_market,
-                user_quote_position.balance_type(),
-            )?,
+        let unsigned_token_amount = get_token_amount(
+            user_quote_position.balance(),
+            spot_market,
             user_quote_position.balance_type(),
         )?;
+
+        let token_amount =
+            get_signed_token_amount(unsigned_token_amount, user_quote_position.balance_type())?;
 
         // dont settle negative pnl to spot borrows when utilization is high (> 80%)
         let max_withdraw_amount =

--- a/programs/drift/src/controller/amm.rs
+++ b/programs/drift/src/controller/amm.rs
@@ -16,7 +16,7 @@ use crate::math::amm_spread::{calculate_spread_reserves, get_spread_reserves};
 use crate::math::casting::Cast;
 use crate::math::constants::{
     CONCENTRATION_PRECISION, K_BPS_UPDATE_SCALE, MAX_CONCENTRATION_COEFFICIENT, MAX_K_BPS_INCREASE,
-    MAX_SQRT_K, PRICE_TO_PEG_PRECISION_RATIO, SPOT_UTILIZATION_PRECISION,
+    MAX_SQRT_K, PRICE_TO_PEG_PRECISION_RATIO,
 };
 use crate::math::cp_curve::get_update_k_result;
 use crate::math::repeg::get_total_fee_lower_bound;
@@ -543,36 +543,21 @@ pub fn update_pool_balances(
     let pnl_to_settle_with_user = if user_unsettled_pnl > 0 {
         min(user_unsettled_pnl, pnl_pool_token_amount.cast::<i128>()?)
     } else {
-        // dont settle negative pnl to spot borrows when utilization is high
-        let utilization =
-            crate::math::spot_balance::calculate_spot_market_utilization(spot_market)?;
+        let token_amount = get_token_amount(
+            user_quote_position.balance(),
+            spot_market,
+            user_quote_position.balance_type(),
+        )?;
 
-        // dont settle negative pnl past 80% util
-        let eighty_percent = (SPOT_UTILIZATION_PRECISION / 10_u128) * 8;
-        if utilization > eighty_percent {
-            // will it increase spot borrows?
-            // -> current position is borrow? => return zero
-            match user_quote_position.balance_type() {
-                SpotBalanceType::Borrow => 0,
-                SpotBalanceType::Deposit => {
-                    // current position is deposit? => will it turn into a borrow?
-                    let current_token_amount = get_token_amount(
-                        user_quote_position.balance(),
-                        spot_market,
-                        user_quote_position.balance_type(),
-                    )?;
-                    // user has enough usdc to pay off neg pnl => settle full amount
-                    // other wise settle full collateral amount
-                    if current_token_amount >= user_unsettled_pnl.unsigned_abs() {
-                        user_unsettled_pnl
-                    } else {
-                        -current_token_amount.cast::<i128>()?
-                    }
-                }
-            }
-        } else {
-            user_unsettled_pnl
-        }
+        // dont settle negative pnl to spot borrows when utilization is high (> 80%)
+        let max_withdraw_amount =
+            -crate::math::orders::get_max_withdraw_for_market_with_token_amount(
+                token_amount.cast()?,
+                spot_market,
+            )?
+            .cast::<i128>()?;
+
+        max_withdraw_amount.max(user_unsettled_pnl)
     };
 
     let pnl_fraction_for_amm = if fraction_for_amm > 0 && pnl_to_settle_with_user < 0 {

--- a/programs/drift/src/controller/amm.rs
+++ b/programs/drift/src/controller/amm.rs
@@ -544,20 +544,8 @@ pub fn update_pool_balances(
         min(user_unsettled_pnl, pnl_pool_token_amount.cast::<i128>()?)
     } else {
         // dont settle negative pnl to spot borrows when utilization is high
-        let deposit_token_amount = get_token_amount(
-            spot_market.deposit_balance,
-            spot_market,
-            &SpotBalanceType::Deposit,
-        )?;
-        let borrow_token_amount = get_token_amount(
-            spot_market.borrow_balance,
-            spot_market,
-            &SpotBalanceType::Borrow,
-        )?;
-        let utilization = crate::math::spot_balance::calculate_utilization(
-            deposit_token_amount,
-            borrow_token_amount,
-        )?;
+        let utilization =
+            crate::math::spot_balance::calculate_spot_market_utilization(spot_market)?;
 
         // dont settle negative pnl past 80% util
         let eighty_percent = (SPOT_UTILIZATION_PRECISION / 10_u128) * 8;

--- a/programs/drift/src/controller/amm.rs
+++ b/programs/drift/src/controller/amm.rs
@@ -21,7 +21,7 @@ use crate::math::constants::{
 use crate::math::cp_curve::get_update_k_result;
 use crate::math::repeg::get_total_fee_lower_bound;
 use crate::math::safe_math::SafeMath;
-use crate::math::spot_balance::{get_signed_token_amount, get_token_amount};
+use crate::math::spot_balance::get_token_amount;
 use crate::math::spot_withdraw::validate_spot_balances;
 use crate::math::{amm, amm_spread, bn, cp_curve, quote_asset::*};
 
@@ -543,14 +543,7 @@ pub fn update_pool_balances(
     let pnl_to_settle_with_user = if user_unsettled_pnl > 0 {
         min(user_unsettled_pnl, pnl_pool_token_amount.cast::<i128>()?)
     } else {
-        let unsigned_token_amount = get_token_amount(
-            user_quote_position.balance(),
-            spot_market,
-            user_quote_position.balance_type(),
-        )?;
-
-        let token_amount =
-            get_signed_token_amount(unsigned_token_amount, user_quote_position.balance_type())?;
+        let token_amount = user_quote_position.get_signed_token_amount(spot_market)?;
 
         // dont settle negative pnl to spot borrows when utilization is high (> 80%)
         let max_withdraw_amount =

--- a/programs/drift/src/controller/amm/tests.rs
+++ b/programs/drift/src/controller/amm/tests.rs
@@ -248,6 +248,100 @@ fn iterative_no_bounds_formualic_k_tests() {
 }
 
 #[test]
+fn update_pool_balances_test_high_util_borrow() {
+    let mut market = PerpMarket {
+        amm: AMM {
+            base_asset_reserve: 5122950819670000,
+            quote_asset_reserve: 488 * AMM_RESERVE_PRECISION,
+            sqrt_k: 500 * AMM_RESERVE_PRECISION,
+            peg_multiplier: 50000,
+            base_asset_amount_with_amm: -122950819670000,
+            total_fee_minus_distributions: 1000 * QUOTE_PRECISION as i128,
+            curve_update_intensity: 100,
+            ..AMM::default()
+        },
+        ..PerpMarket::default()
+    };
+    let now = 33928058;
+
+    let mut spot_market = SpotMarket {
+        cumulative_deposit_interest: SPOT_CUMULATIVE_INTEREST_PRECISION,
+        cumulative_borrow_interest: SPOT_CUMULATIVE_INTEREST_PRECISION,
+        ..SpotMarket::default()
+    };
+    // 100% util
+    spot_market.deposit_balance = 10_u128.pow(19_u32);
+    spot_market.borrow_balance = 10_u128.pow(19_u32);
+
+    // would lead to a borrow
+    let mut spot_position = SpotPosition::default();
+
+    let unsettled_pnl = -100;
+    let to_settle_with_user = update_pool_balances(
+        &mut market,
+        &mut spot_market,
+        &spot_position,
+        unsettled_pnl,
+        now,
+    )
+    .unwrap();
+    assert_eq!(to_settle_with_user, 0);
+
+    // util is low => neg settle ok
+    spot_market.borrow_balance = 0;
+    let unsettled_pnl = -100;
+    let to_settle_with_user = update_pool_balances(
+        &mut market,
+        &mut spot_market,
+        &spot_position,
+        unsettled_pnl,
+        now,
+    )
+    .unwrap();
+    assert_eq!(to_settle_with_user, unsettled_pnl);
+
+    // util is high
+    spot_market.borrow_balance = 10_u128.pow(19_u32);
+    // user has a little bit deposited => settle how much they have deposited
+    update_spot_balances(
+        50,
+        &SpotBalanceType::Deposit,
+        &mut spot_market,
+        &mut spot_position,
+        false,
+    )
+    .unwrap();
+    let to_settle_with_user = update_pool_balances(
+        &mut market,
+        &mut spot_market,
+        &spot_position,
+        unsettled_pnl,
+        now,
+    )
+    .unwrap();
+    assert_eq!(to_settle_with_user, -50);
+
+    // user has a lot deposited => settle full pnl
+    update_spot_balances(
+        500,
+        &SpotBalanceType::Deposit,
+        &mut spot_market,
+        &mut spot_position,
+        false,
+    )
+    .unwrap();
+    let to_settle_with_user = update_pool_balances(
+        &mut market,
+        &mut spot_market,
+        &spot_position,
+        unsettled_pnl,
+        now,
+    )
+    .unwrap();
+    assert_eq!(to_settle_with_user, -100);
+}
+
+#[test]
 fn update_pool_balances_test() {
     let mut market = PerpMarket {
         amm: AMM {
@@ -269,12 +363,15 @@ fn update_pool_balances_test() {
         cumulative_borrow_interest: SPOT_CUMULATIVE_INTEREST_PRECISION,
         ..SpotMarket::default()
     };
+
+    let spot_position = SpotPosition::default();
+
     let to_settle_with_user =
-        update_pool_balances(&mut market, &mut spot_market, 100, now).unwrap();
+        update_pool_balances(&mut market, &mut spot_market, &spot_position, 100, now).unwrap();
     assert_eq!(to_settle_with_user, 0);
 
     let to_settle_with_user =
-        update_pool_balances(&mut market, &mut spot_market, -100, now).unwrap();
+        update_pool_balances(&mut market, &mut spot_market, &spot_position, -100, now).unwrap();
     assert_eq!(to_settle_with_user, -100);
     assert!(market.amm.fee_pool.balance() > 0);
 
@@ -294,7 +391,7 @@ fn update_pool_balances_test() {
     assert_eq!(amm_fee_pool_token_amount, 1);
 
     let to_settle_with_user =
-        update_pool_balances(&mut market, &mut spot_market, 100, now).unwrap();
+        update_pool_balances(&mut market, &mut spot_market, &spot_position, 100, now).unwrap();
     assert_eq!(to_settle_with_user, 99);
     let amm_fee_pool_token_amount = get_token_amount(
         market.amm.fee_pool.balance(),
@@ -312,7 +409,7 @@ fn update_pool_balances_test() {
     assert_eq!(amm_fee_pool_token_amount, 1);
 
     market.amm.total_fee_minus_distributions = 0;
-    update_pool_balances(&mut market, &mut spot_market, -1, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, -1, now).unwrap();
     let amm_fee_pool_token_amount = get_token_amount(
         market.amm.fee_pool.balance(),
         &spot_market,
@@ -332,6 +429,7 @@ fn update_pool_balances_test() {
     update_pool_balances(
         &mut market,
         &mut spot_market,
+        &spot_position,
         -(100_000 * QUOTE_PRECISION as i128),
         now,
     )
@@ -354,7 +452,14 @@ fn update_pool_balances_test() {
     // negative fee pool
     market.amm.total_fee_minus_distributions = -8_008_123_456;
 
-    update_pool_balances(&mut market, &mut spot_market, 1_000_987_789, now).unwrap();
+    update_pool_balances(
+        &mut market,
+        &mut spot_market,
+        &spot_position,
+        1_000_987_789,
+        now,
+    )
+    .unwrap();
     let amm_fee_pool_token_amount = get_token_amount(
         market.amm.fee_pool.balance(),
         &spot_market,
@@ -439,7 +544,8 @@ fn update_pool_balances_fee_to_revenue_test() {
         100 * QUOTE_PRECISION
     );
 
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    let spot_position = SpotPosition::default();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
 
     assert_eq!(market.amm.fee_pool.scaled_balance, 44000000000000000);
     assert_eq!(market.pnl_pool.scaled_balance, 50000000000000000);
@@ -496,6 +602,7 @@ fn update_pool_balances_revenue_to_fee_test() {
         decimals: 6,
         ..SpotMarket::default()
     };
+    let spot_position = SpotPosition::default();
 
     let prev_fee_pool = market.amm.fee_pool.scaled_balance;
     let prev_pnl_pool = market.amm.fee_pool.scaled_balance;
@@ -528,7 +635,7 @@ fn update_pool_balances_revenue_to_fee_test() {
         100 * SPOT_BALANCE_PRECISION
     );
 
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
 
     assert_eq!(
         market.amm.fee_pool.scaled_balance,
@@ -557,8 +664,7 @@ fn update_pool_balances_revenue_to_fee_test() {
         spot_market.revenue_pool.scaled_balance,
         100 * SPOT_BALANCE_PRECISION
     );
-
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
 
     assert_eq!(
         market.amm.fee_pool.scaled_balance,
@@ -583,7 +689,7 @@ fn update_pool_balances_revenue_to_fee_test() {
     assert_eq!(spot_market_vault_amount, 200000000); // total spot_market deposit balance unchanged during transfers
 
     // calling multiple times doesnt effect other than fee pool -> pnl pool
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
     assert_eq!(
         market.amm.fee_pool.scaled_balance,
         5 * SPOT_BALANCE_PRECISION
@@ -593,7 +699,7 @@ fn update_pool_balances_revenue_to_fee_test() {
     assert_eq!(market.amm.total_fee_withdrawn, 0);
     assert_eq!(spot_market.revenue_pool.scaled_balance, 0);
 
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
     assert_eq!(
         market.amm.fee_pool.scaled_balance,
         5 * SPOT_BALANCE_PRECISION
@@ -609,7 +715,7 @@ fn update_pool_balances_revenue_to_fee_test() {
 
     let spot_market_backup = spot_market;
     let market_backup = market;
-    assert!(update_pool_balances(&mut market, &mut spot_market, 0, now).is_err()); // assert is_err if any way has revenue pool above deposit balances
+    assert!(update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).is_err()); // assert is_err if any way has revenue pool above deposit balances
     spot_market = spot_market_backup;
     market = market_backup;
     spot_market.deposit_balance += 9900000001000;
@@ -622,7 +728,7 @@ fn update_pool_balances_revenue_to_fee_test() {
     assert_eq!(spot_market.deposit_balance, 10100000001000);
     assert_eq!(spot_market_vault_amount, 10100000001);
 
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
     assert_eq!(spot_market.deposit_balance, 10100000001000);
     assert_eq!(spot_market.revenue_pool.scaled_balance, 9800000001000);
     assert_eq!(market.amm.fee_pool.scaled_balance, 105000000000);
@@ -636,7 +742,7 @@ fn update_pool_balances_revenue_to_fee_test() {
     assert_eq!(market.insurance_claim.last_revenue_withdraw_ts, 33928058);
 
     // calling again only does fee -> pnl pool
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
     assert_eq!(market.amm.fee_pool.scaled_balance, 5000000000);
     assert_eq!(market.pnl_pool.scaled_balance, 295000000000);
     assert_eq!(market.amm.total_fee_minus_distributions, -9800000000);
@@ -649,7 +755,7 @@ fn update_pool_balances_revenue_to_fee_test() {
     assert_eq!(market.insurance_claim.last_revenue_withdraw_ts, 33928058);
 
     // calling again does nothing
-    update_pool_balances(&mut market, &mut spot_market, 0, now).unwrap();
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).unwrap();
     assert_eq!(market.amm.fee_pool.scaled_balance, 5000000000);
     assert_eq!(market.pnl_pool.scaled_balance, 295000000000);
     assert_eq!(market.amm.total_fee_minus_distributions, -9800000000);
@@ -693,7 +799,9 @@ fn update_pool_balances_revenue_to_fee_test() {
     spot_market.revenue_pool.scaled_balance = 9800000001000;
     let market_backup = market;
     let spot_market_backup = spot_market;
-    assert!(update_pool_balances(&mut market, &mut spot_market, 0, now + 3600).is_err()); // assert is_err if any way has revenue pool above deposit balances
+    assert!(
+        update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now + 3600).is_err()
+    ); // assert is_err if any way has revenue pool above deposit balances
     market = market_backup;
     spot_market = spot_market_backup;
     spot_market.deposit_balance += 9800000000001;
@@ -709,8 +817,8 @@ fn update_pool_balances_revenue_to_fee_test() {
         33928058 + 3600
     );
 
-    assert!(update_pool_balances(&mut market, &mut spot_market, 0, now).is_err()); // now timestamp passed is wrong
-    update_pool_balances(&mut market, &mut spot_market, 0, now + 3600).unwrap();
+    assert!(update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now).is_err()); // now timestamp passed is wrong
+    update_pool_balances(&mut market, &mut spot_market, &spot_position, 0, now + 3600).unwrap();
 
     assert_eq!(market.insurance_claim.last_revenue_withdraw_ts, 33931658);
     assert_eq!(spot_market.insurance_fund.last_revenue_settle_ts, 33931658);

--- a/programs/drift/src/controller/amm/tests.rs
+++ b/programs/drift/src/controller/amm/tests.rs
@@ -363,6 +363,7 @@ fn update_pool_balances_test() {
         cumulative_borrow_interest: SPOT_CUMULATIVE_INTEREST_PRECISION,
         ..SpotMarket::default()
     };
+    spot_market.deposit_balance = 10_u128.pow(19_u32);
 
     let spot_position = SpotPosition::default();
 
@@ -446,8 +447,8 @@ fn update_pool_balances_test() {
         market.pnl_pool.balance_type(),
     )
     .unwrap();
-    assert_eq!(pnl_pool_token_amount, 99_000_000_000 + 2);
-    assert_eq!(amm_fee_pool_token_amount, (1_000 * QUOTE_PRECISION));
+    assert_eq!(pnl_pool_token_amount, 1_650_000_000 + 3);
+    assert_eq!(amm_fee_pool_token_amount, 16_666_666);
 
     // negative fee pool
     market.amm.total_fee_minus_distributions = -8_008_123_456;
@@ -472,7 +473,7 @@ fn update_pool_balances_test() {
         market.pnl_pool.balance_type(),
     )
     .unwrap();
-    assert_eq!(pnl_pool_token_amount, 99_000_000_000 + 2 - 987_789);
+    assert_eq!(pnl_pool_token_amount, 665678880);
     assert_eq!(amm_fee_pool_token_amount, 0);
 }
 

--- a/programs/drift/src/controller/pnl.rs
+++ b/programs/drift/src/controller/pnl.rs
@@ -119,8 +119,14 @@ pub fn settle_pnl(
     let user_unsettled_pnl: i128 =
         user.perp_positions[position_index].get_claimable_pnl(oracle_price, max_pnl_pool_excess)?;
 
-    let pnl_to_settle_with_user =
-        update_pool_balances(perp_market, spot_market, user_unsettled_pnl, now)?;
+    let pnl_to_settle_with_user = update_pool_balances(
+        perp_market,
+        spot_market,
+        user.get_quote_spot_position(),
+        user_unsettled_pnl,
+        now,
+    )?;
+
     if user_unsettled_pnl == 0 {
         msg!("User has no unsettled pnl for market {}", market_index);
         return Ok(());

--- a/programs/drift/src/math/orders.rs
+++ b/programs/drift/src/math/orders.rs
@@ -576,6 +576,13 @@ pub fn get_max_fill_amounts(
 fn get_max_fill_amounts_for_market(user: &User, market: &SpotMarket) -> DriftResult<u128> {
     let position_index = user.get_spot_position_index(market.market_index)?;
     let token_amount = user.spot_positions[position_index].get_signed_token_amount(market)?;
+    get_max_withdraw_for_market_with_token_amount(token_amount, market)
+}
+
+pub fn get_max_withdraw_for_market_with_token_amount(
+    token_amount: i128,
+    market: &SpotMarket,
+) -> DriftResult<u128> {
     let available_borrow_liquidity = calculate_availability_borrow_liquidity(market)?;
     token_amount
         .max(0)

--- a/programs/drift/src/math/orders.rs
+++ b/programs/drift/src/math/orders.rs
@@ -579,6 +579,7 @@ fn get_max_fill_amounts_for_market(user: &User, market: &SpotMarket) -> DriftRes
     get_max_withdraw_for_market_with_token_amount(token_amount, market)
 }
 
+#[inline(always)]
 pub fn get_max_withdraw_for_market_with_token_amount(
     token_amount: i128,
     market: &SpotMarket,

--- a/programs/drift/src/math/spot_balance.rs
+++ b/programs/drift/src/math/spot_balance.rs
@@ -106,10 +106,7 @@ pub fn calculate_utilization(
     Ok(utilization)
 }
 
-pub fn calculate_accumulated_interest(
-    spot_market: &SpotMarket,
-    now: i64,
-) -> DriftResult<InterestAccumulated> {
+pub fn calculate_spot_market_utilization(spot_market: &SpotMarket) -> DriftResult<u128> {
     let deposit_token_amount = get_token_amount(
         spot_market.deposit_balance,
         spot_market,
@@ -120,8 +117,16 @@ pub fn calculate_accumulated_interest(
         spot_market,
         &SpotBalanceType::Borrow,
     )?;
-
     let utilization = calculate_utilization(deposit_token_amount, borrow_token_amount)?;
+
+    Ok(utilization)
+}
+
+pub fn calculate_accumulated_interest(
+    spot_market: &SpotMarket,
+    now: i64,
+) -> DriftResult<InterestAccumulated> {
+    let utilization = calculate_spot_market_utilization(spot_market)?;
 
     if utilization == 0 {
         return Ok(InterestAccumulated {


### PR DESCRIPTION
- when spot utilization is high we dont want to settle negative pnl which would lead to more borrows 
- also added a new helper fcn `calculate_spot_market_utilization`