### PR TITLE
program: place liquidation orders as liquidators take over user perp positions

### DIFF
--- a/programs/drift/src/controller/liquidation/tests.rs
+++ b/programs/drift/src/controller/liquidation/tests.rs
@@ -584,7 +584,7 @@ pub mod liquidate_perp {
         assert_eq!(user.perp_positions[0].quote_asset_amount, -101000000);
         assert_eq!(user.perp_positions[0].quote_entry_amount, -75000000);
         assert_eq!(user.perp_positions[0].quote_break_even_amount, -76000000);
-        assert_eq!(user.perp_positions[0].open_orders, 0);
+        assert_eq!(user.perp_positions[0].open_orders, 1);
         assert_eq!(user.perp_positions[0].open_bids, 0);
 
         assert_eq!(
@@ -943,7 +943,7 @@ pub mod liquidate_perp {
 
         assert_eq!(user.perp_positions[0].base_asset_amount, 9999000000000);
         assert_eq!(user.perp_positions[0].quote_asset_amount, -1499902000000);
-        assert_eq!(user.perp_positions[0].open_orders, 0);
+        assert_eq!(user.perp_positions[0].open_orders, 1);
         assert_eq!(user.perp_positions[0].open_bids, 0);
 
         assert_eq!(

--- a/programs/drift/src/controller/orders/amm_jit_tests.rs
+++ b/programs/drift/src/controller/orders/amm_jit_tests.rs
@@ -227,6 +227,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -403,6 +404,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -586,6 +588,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -777,6 +780,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -976,6 +980,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -1175,6 +1180,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -1350,6 +1356,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -1536,6 +1543,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -1770,6 +1778,7 @@ pub mod amm_jit {
                 slot,
                 false,
                 true,
+                0,
             )
             .unwrap();
 
@@ -2041,6 +2050,7 @@ pub mod amm_jit {
                 slot,
                 false,
                 true,
+                0,
             )
             .unwrap();
 
@@ -2254,6 +2264,7 @@ pub mod amm_jit {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 

--- a/programs/drift/src/controller/orders/tests.rs
+++ b/programs/drift/src/controller/orders/tests.rs
@@ -2459,6 +2459,7 @@ pub mod fulfill_order {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -2671,6 +2672,7 @@ pub mod fulfill_order {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -2861,6 +2863,7 @@ pub mod fulfill_order {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -3022,6 +3025,7 @@ pub mod fulfill_order {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 
@@ -3413,6 +3417,7 @@ pub mod fulfill_order {
             slot,
             false,
             true,
+            0,
         )
         .unwrap();
 

--- a/programs/drift/src/math/orders.rs
+++ b/programs/drift/src/math/orders.rs
@@ -341,6 +341,10 @@ pub fn should_cancel_reduce_only_order(
     Ok(should_cancel)
 }
 
+pub fn should_cancel_liquidation_order(user: &User, order_index: usize) -> DriftResult<bool> {
+    Ok(!user.is_being_liquidated() && user.orders[order_index].is_liquidation_order())
+}
+
 pub fn order_breaches_oracle_price_limits(
     order: &Order,
     oracle_price: i64,

--- a/programs/drift/src/state/events.rs
+++ b/programs/drift/src/state/events.rs
@@ -271,6 +271,7 @@ pub enum OrderActionExplanation {
     ReduceOnlyOrderIncreasedPosition,
     OrderFillWithSerum,
     NoBorrowLiquidity,
+    NoLongerBeingLiquidated,
 }
 
 impl Default for OrderAction {

--- a/programs/drift/src/state/user.rs
+++ b/programs/drift/src/state/user.rs
@@ -726,6 +726,10 @@ impl Order {
     pub fn is_limit_order(&self) -> bool {
         matches!(self.order_type, OrderType::Limit | OrderType::TriggerLimit)
     }
+
+    pub fn is_liquidation_order(&self) -> bool {
+        self.order_type == OrderType::Liquidation
+    }
 }
 
 impl Default for Order {
@@ -774,6 +778,7 @@ pub enum OrderType {
     TriggerMarket,
     TriggerLimit,
     Oracle,
+    Liquidation,
 }
 
 impl Default for OrderType {

--- a/programs/drift/src/validation/order.rs
+++ b/programs/drift/src/validation/order.rs
@@ -36,6 +36,10 @@ pub fn validate_order(
         OrderType::Oracle => {
             validate_oracle_order(order, market.amm.order_step_size, market.amm.min_order_size)?
         }
+        OrderType::Liquidation => {
+            msg!("User cannot submit liquidation orders");
+            return Err(ErrorCode::InvalidOrder);
+        }
     }
 
     Ok(())
@@ -392,6 +396,10 @@ pub fn validate_spot_order(
         }
         OrderType::TriggerLimit => validate_trigger_limit_order(order, step_size, min_order_size)?,
         OrderType::Oracle => validate_oracle_order(order, step_size, min_order_size)?,
+        OrderType::Liquidation => {
+            msg!("User cannot submit liquidation orders");
+            return Err(ErrorCode::InvalidOrder);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
During liquidations, we want user perp positions to enter the jit auction while liquidators simultaneously take over their positions. This allows active mm's and the amm to take over the liquidated users perp position, making liquidations less risky.