### PR TITLE
sdk: expect signTransaction from wallet adapters to return a copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- ts-sdk: expect signTransaction from wallet adapters to return a copy ([#299](https://github.com/drift-labs/protocol-v2/pull/299))
+
 ### Breaking
 
 ## [2.8.0] - 2022-12-22

--- a/sdk/src/tx/retryTxSender.ts
+++ b/sdk/src/tx/retryTxSender.ts
@@ -52,11 +52,11 @@ export class RetryTxSender implements TxSender {
 			opts = this.provider.opts;
 		}
 
-		if (!preSigned) {
-			await this.prepareTx(tx, additionalSigners, opts);
-		}
+		const signedTx = preSigned
+			? tx
+			: await this.prepareTx(tx, additionalSigners, opts);
 
-		const rawTransaction = tx.serialize();
+		const rawTransaction = signedTx.serialize();
 		const startTime = this.getTimestamp();
 
 		let txid: TransactionSignature;
@@ -123,14 +123,14 @@ export class RetryTxSender implements TxSender {
 			)
 		).blockhash;
 
-		await this.provider.wallet.signTransaction(tx);
+		const signedTx = await this.provider.wallet.signTransaction(tx);
 		additionalSigners
 			.filter((s): s is Signer => s !== undefined)
 			.forEach((kp) => {
-				tx.partialSign(kp);
+				signedTx.partialSign(kp);
 			});
 
-		return tx;
+		return signedTx;
 	}
 
 	async confirmTransaction(


### PR DESCRIPTION
Addresses this:
https://drift-protocol.slack.com/archives/C01V3SKCS95/p1671474413750489
/
https://twitter.com/bfriel_/status/1604641581855698944?s=21&t=hwlZd6lJB4p9ZG3WjpQCXw