### PR TITLE
fix: use consistent oracles and market indexes when creating account subscriber in DriftClient constructor

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -166,7 +166,7 @@ export class DriftClient {
 			const {
 				perpMarketIndexes: envPerpMarketIndexes,
 				spotMarketIndexes: envSpotMarketIndexes,
-				oracleInfos: envOralceInfos,
+				oracleInfos: envOracleInfos,
 			} = getMarketsAndOraclesForSubscription(config.env);
 			perpMarketIndexes = perpMarketIndexes
 				? perpMarketIndexes
@@ -174,7 +174,7 @@ export class DriftClient {
 			spotMarketIndexes = spotMarketIndexes
 				? spotMarketIndexes
 				: envSpotMarketIndexes;
-			oracleInfos = oracleInfos ? oracleInfos : envOralceInfos;
+			oracleInfos = oracleInfos ? oracleInfos : envOracleInfos;
 		}
 
 		if (config.accountSubscription?.type === 'polling') {
@@ -188,9 +188,9 @@ export class DriftClient {
 		} else {
 			this.accountSubscriber = new WebSocketDriftClientAccountSubscriber(
 				this.program,
-				config.perpMarketIndexes ?? [],
-				config.spotMarketIndexes ?? [],
-				config.oracleInfos ?? []
+				perpMarketIndexes ?? [],
+				spotMarketIndexes ?? [],
+				oracleInfos ?? []
 			);
 		}
 		this.eventEmitter = this.accountSubscriber.eventEmitter;


### PR DESCRIPTION
When creating a polling subscriber the `DriftClient` constructor uses values provided by `DriftClientConfig` param first and otherwise falls back to value returned by `getMarketsAndOraclesForSubscription(config.env)`. When creating a websocket subscriber however the constructor only uses the value provided by the config. It lead to some confusion on my part when trying to create a new `DriftClient` instance using a config that only specified the `env` property but not the `oracleInfos` etc. of the config object. It seems like this should be consistent unless there is some reason I am missing.