### PR TITLE
sdk: fix deprecated calls to `@solana/web3.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- ts-sdk: fix deprecated calls to `@solana/web3.js` ([#299](https://github.com/drift-labs/protocol-v2/pull/307))
+
 ### Breaking
 
 ## [2.9.0] - 2022-12-23

--- a/sdk/src/events/fetchLogs.ts
+++ b/sdk/src/events/fetchLogs.ts
@@ -5,6 +5,7 @@ import {
 	PublicKey,
 	TransactionResponse,
 	TransactionSignature,
+	VersionedTransactionResponse,
 } from '@solana/web3.js';
 import { WrappedEvents } from './types';
 
@@ -18,7 +19,9 @@ type FetchLogsResponse = {
 	mostRecentBlockTime: number | undefined;
 };
 
-function mapTransactionResponseToLog(transaction: TransactionResponse): Log {
+function mapTransactionResponseToLog(
+	transaction: TransactionResponse | VersionedTransactionResponse
+): Log {
 	return {
 		txSig: transaction.transaction.signatures[0],
 		slot: transaction.slot,
@@ -63,7 +66,10 @@ export async function fetchLogs(
 			chunkedSignatures.map(async (chunk) => {
 				const transactions = await connection.getTransactions(
 					chunk.map((confirmedSignature) => confirmedSignature.signature),
-					finality
+					{
+						commitment: finality,
+						maxSupportedTransactionVersion: 0,
+					}
 				);
 
 				return transactions.reduce((logs, transaction) => {


### PR DESCRIPTION
Seeing this error from some mainnet RPCs (rpcpool), this fix should address it:

![image](https://user-images.githubusercontent.com/6348407/209411067-689d59da-262b-4de6-88bb-c65de03f14c4.png)
