### PR TITLE
fix(sdk): oracle info required for calculating trade slippage

### DIFF
--- a/sdk/src/examples/makeTradeExample.ts
+++ b/sdk/src/examples/makeTradeExample.ts
@@ -12,6 +12,7 @@ import {
 	calculateTradeSlippage,
 	BulkAccountLoader,
 	PerpMarkets,
+	getMarketsAndOraclesForSubscription,
 	PRICE_PRECISION,
 	QUOTE_PRECISION,
 } from '..';
@@ -74,10 +75,7 @@ const main = async () => {
 		connection,
 		wallet: provider.wallet,
 		programID: driftPublicKey,
-		perpMarketIndexes: PerpMarkets[cluster].map((market) => market.marketIndex),
-		spotMarketIndexes: SpotMarkets[cluster].map(
-			(spotMarket) => spotMarket.marketIndex
-		),
+		...getMarketsAndOraclesForSubscription(cluster),
 		accountSubscription: {
 			type: 'polling',
 			accountLoader: bulkAccountLoader,
@@ -139,7 +137,7 @@ const main = async () => {
 			longAmount,
 			solMarketAccount,
 			'quote',
-			undefined
+			driftClient.getOracleDataForPerpMarket(solMarketInfo.marketIndex)
 		)[0],
 		PRICE_PRECISION
 	);

--- a/sdk/src/math/trade.ts
+++ b/sdk/src/math/trade.ts
@@ -61,7 +61,7 @@ export function calculateTradeSlippage(
 	amount: BN,
 	market: PerpMarketAccount,
 	inputAssetType: AssetType = 'quote',
-	oraclePriceData?: OraclePriceData,
+	oraclePriceData: OraclePriceData,
 	useSpread = true
 ): [BN, BN, BN, BN] {
 	let oldPrice: BN;


### PR DESCRIPTION
I noticed the oracle data is required in the functions called by `calculateTradeSlippage`, so I added this to the example and made the argument required in the `trade.ts` function.