### PR TITLE
sdk: use npx for tsc

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -11,7 +11,7 @@
 	},
 	"scripts": {
 		"lint": "eslint './**/*.{ts,tsx}' --quiet",
-		"build": "yarn clean && tsc",
+		"build": "yarn clean && npx tsc",
 		"clean": "rm -rf lib",
 		"test": "mocha -r ts-node/register tests/**/*.ts",
 		"test:inspect": "mocha --inspect-brk -r ts-node/register tests/**/*.ts",


### PR DESCRIPTION
Keep getting the error `command tsc not found` when I try to build the sdk even though typescript is installed globally. Probably something went wrong after switching node version to 18, and there might be another way to fix this on my machine specifically, but I think this way is good anyway because it's more foolproof for dev machines that don't even have typescript installed globally.