### PR TITLE
ts-sdk: add slot data to UserAccount getters

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -3353,9 +3353,11 @@ export class DriftClient {
 	 * @param inMarketIndex the market index of the token you're selling
 	 * @param outAssociatedTokenAccount the token account to receive the token being sold on jupiter
 	 * @param inAssociatedTokenAccount the token account to
-	 * @param amount the amount of the token to sell
+	 * @param amount the amount of TokenIn, regardless of swapMode
 	 * @param slippageBps the max slippage passed to jupiter api
+	 * @param swapMode jupiter swapMode (ExactIn or ExactOut), default is ExactIn
 	 * @param route the jupiter route to use for the swap
+	 * @param reduceOnly specify if In or Out token on the drift account must reduceOnly, checked at end of swap
 	 * @param txParams
 	 */
 	public async swap({


### PR DESCRIPTION
PR adds options to request the slot of the account data when requesting specific userAccount data (perp positions, open orders , ...) how recent the data is currently ambiguous.

# Use case:
 
User subscribes to recent events. if the event slot is greater than slot of local UserAccount, then local UserAccount data should be considered stale.

if you're concerned about your current base asset amount:
```
// receiving OrderActionRecords via EventSubscriber
// to calculate current base position
const perpPosition = user.getPerpPositionAndSlot(mktIndex);
let currentBase = perpPosition.baseAssetAmount;
if (event.slot > perpPosition.slot) {
  currentBase = currentBase.add(event.makerOrderBaseAssetAmount); // use taker or maker value as appropriate
}
```