### PR TITLE
BUGFIX: DLOBFilterFcn should indicate if a node is used, not skipped

### DIFF
--- a/sdk/src/dlob/DLOB.ts
+++ b/sdk/src/dlob/DLOB.ts
@@ -1111,7 +1111,7 @@ export class DLOB {
 					continue;
 				}
 
-				if (filterFcn && filterFcn(bestGenerator.next.value)) {
+				if (filterFcn && !filterFcn(bestGenerator.next.value)) {
 					bestGenerator.next = bestGenerator.generator.next();
 					continue;
 				}


### PR DESCRIPTION
The semantics implemented on PR #644 are the inverse of what's documented for the function, and of the usual behavior for filter.