### PR TITLE
surface errors from jupiter api

### DIFF
--- a/sdk/src/jupiter/jupiterClient.ts
+++ b/sdk/src/jupiter/jupiterClient.ts
@@ -336,6 +336,13 @@ export class JupiterClient {
 				}),
 			})
 		).json();
+		if (!('swapTransaction' in resp)) {
+			throw new Error(
+				`swapTransaction not found, error from Jupiter: ${resp.error} ${
+					', ' + resp.message ?? ''
+				}`
+			);
+		}
 		const { swapTransaction } = resp;
 
 		try {

--- a/sdk/src/math/auction.ts
+++ b/sdk/src/math/auction.ts
@@ -1,5 +1,5 @@
 import { isOneOfVariant, isVariant, Order, PositionDirection } from '../types';
-import { BN, ONE, ZERO } from '../.';
+import { BN, getVariant, ONE, ZERO } from '../.';
 
 export function isAuctionComplete(order: Order, slot: number): boolean {
 	if (order.auctionDuration === 0) {
@@ -31,7 +31,9 @@ export function getAuctionPrice(
 	} else if (isVariant(order.orderType, 'oracle')) {
 		return getAuctionPriceForOracleOffsetAuction(order, slot, oraclePrice);
 	} else {
-		throw Error(`Cant get auction price for order type ${order.orderType}`);
+		throw Error(
+			`Cant get auction price for order type ${getVariant(order.orderType)}`
+		);
 	}
 }
 


### PR DESCRIPTION
Currently errors are suppressed, but some of these errors from jupiter are helpful for sdk users.

```
{
  statusCode: 429,
  error: 'Too Many Requests',
  message: 'You have exceeded the rate limit of 210 requests per minute.'
}
```

```
{
  error: 'AMM was not found, amm_key: 5BUwFW4nRbftYTDMbgxykoFWqWHPzahFSNAaaaJtVKsq'
}
```