### PR TITLE
fix(sdk): add fetchIfUnloaded to pollingIfStakeAccountSubscriber, account loader logic

### DIFF
--- a/sdk/src/accounts/bulkAccountLoader.ts
+++ b/sdk/src/accounts/bulkAccountLoader.ts
@@ -78,6 +78,7 @@ export class BulkAccountLoader {
 		if (existingAccountToLoad) {
 			existingAccountToLoad.callbacks.delete(callbackId);
 			if (existingAccountToLoad.callbacks.size === 0) {
+				this.bufferAndSlotMap.delete(publicKey.toString());
 				this.accountsToLoad.delete(existingAccountToLoad.publicKey.toString());
 			}
 		}
@@ -153,9 +154,11 @@ export class BulkAccountLoader {
 		const requests = new Array<{ methodName: string; args: any }>();
 		for (const accountsToLoadChunk of accountsToLoadChunks) {
 			const args = [
-				accountsToLoadChunk.map((accountToLoad) => {
-					return accountToLoad.publicKey.toBase58();
-				}),
+				accountsToLoadChunk
+					.filter(accountToLoad => accountToLoad.callbacks.size > 0)
+					.map((accountToLoad) => {
+						return accountToLoad.publicKey.toBase58();
+					}),
 				{ commitment: this.commitment },
 			];
 
@@ -190,6 +193,10 @@ export class BulkAccountLoader {
 
 			const accountsToLoad = accountsToLoadChunks[i];
 			accountsToLoad.forEach((accountToLoad, j) => {
+				if (accountToLoad.callbacks.size === 0) {
+					return;
+				}
+
 				const key = accountToLoad.publicKey.toBase58();
 				const oldRPCResponse = this.bufferAndSlotMap.get(key);
 

--- a/sdk/src/accounts/pollingInsuranceFundStakeAccountSubscriber.ts
+++ b/sdk/src/accounts/pollingInsuranceFundStakeAccountSubscriber.ts
@@ -54,6 +54,7 @@ export class PollingInsuranceFundStakeAccountSubscriber
 
 		await this.addToAccountLoader();
 
+		await this.fetchIfUnloaded();
 		if (this.doesAccountExist()) {
 			this.eventEmitter.emit('update');
 		}


### PR DESCRIPTION
2 issues fixed in this PR

1. Obvious one that does fix the UI issue is that `fetchIfUnloaded()` is missing in the `subscribe()` function of `pollingInsuranceFundStakeAccountSubscriber`

2. Technically, even if `fetchIfUnloaded()` was missing from `subscribe()`, we expected the `BulkAccountLoader` to still poll and update the data of account.

- However, due to race conditions, particularly transitioning from account unsubscribing to subscribing, the callbackId attached to the account was `undefined` when it was the account's turn to be handled with fresh data on subscribe. Hence even though the correct data was fetched, the callback to attach the data to the account did not execute because it was missing. The callback was only added after the fetch (race conditions at play), but `bufferAndSlotMap` has already set the mapped the new data to the account, causing subsequent polls to skip all conditions in the account/data handling logic. The fix for this is to skip handling newly fetched data when the account has no callback.

- Another reason why all the conditions are skipped is because `bufferAndSlotMap` contains the old account's data, which wasn't deleted when the old account was unsubscribed. When the new account with the same public key is subscribed, the `bufferAndSlotMap` infers that the new same-public key account has this old data, which is wrong. (We have two source of truths of which account has what data - `bufferAndSlotMap` and the accounts themselves - and unless we do a massive overhaul of our account classes, we need to be more vigilant in ensuring that the truths are synced). The fix for this currently is to ensure that the data is deleted when the account has unsubscribed

- over here we can see that when the code wants to handle the account callback, the `Map` has a size of 0, which refers to the number of callbacks assigned to that pubkey. the callback was only added after that
![Screenshot 2023-12-08 at 2 28 09 PM](https://github.com/drift-labs/protocol-v2/assets/12388321/d1883f33-6013-48b7-993f-da34593fd28f)
