### PR TITLE
bigz/sdk-getPerpPositionForUserAccount-undefined-if-empty

### DIFF
--- a/sdk/src/user.ts
+++ b/sdk/src/user.ts
@@ -160,7 +160,7 @@ export class User {
 		userAccount: UserAccount,
 		marketIndex: number
 	): PerpPosition | undefined {
-		return userAccount.perpPositions.find(
+		return this.getActivePerpPositionsForUserAccount(userAccount).find(
 			(position) => position.marketIndex === marketIndex
 		);
 	}


### PR DESCRIPTION
```
getPerpPosition(marketInfo.marketIndex);
```

might not return undefined for empty position without this change