### PR TITLE
bigz/add-oracle-volatility-protections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Features
+- program: use decayed last_oracle_conf_pct as lower bound for update ([#840](https://github.com/drift-labs/protocol-v2/pull/840))
 
 ### Fixes
 

--- a/programs/drift/src/math/amm.rs
+++ b/programs/drift/src/math/amm.rs
@@ -8,7 +8,7 @@ use crate::error::{DriftResult, ErrorCode};
 use crate::math::bn::U192;
 use crate::math::casting::Cast;
 use crate::math::constants::{
-    BID_ASK_SPREAD_PRECISION, BID_ASK_SPREAD_PRECISION_I128, CONCENTRATION_PRECISION,
+    BID_ASK_SPREAD_PRECISION_I128, CONCENTRATION_PRECISION,
     DEFAULT_MAX_TWAP_UPDATE_PRICE_BAND_DENOMINATOR, FIVE_MINUTE, ONE_HOUR, ONE_MINUTE,
     PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO, PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO_I128,
     PRICE_TO_PEG_PRECISION_RATIO, QUOTE_PRECISION_I64,
@@ -428,14 +428,11 @@ pub fn update_oracle_price_twap(
 
         amm.last_oracle_normalised_price = capped_oracle_update_price;
         amm.historical_oracle_data.last_oracle_price = oracle_price_data.price;
-        amm.last_oracle_conf_pct = oracle_price_data
-            .confidence
-            .max(
-                amm.last_oracle_conf_pct
-                    .safe_sub(amm.last_oracle_conf_pct / 5)?,
-            )
-            .safe_mul(BID_ASK_SPREAD_PRECISION)?
-            .safe_div(reserve_price)? as u64;
+
+        // use decayed last_oracle_conf_pct as lower bound
+        amm.last_oracle_conf_pct =
+            amm.update_last_oracle_conf_pct(oracle_price_data.confidence, reserve_price, now)?;
+
         amm.historical_oracle_data.last_oracle_delay = oracle_price_data.delay;
         amm.last_oracle_reserve_price_spread_pct =
             calculate_oracle_reserve_price_spread_pct(amm, oracle_price_data, Some(reserve_price))?;

--- a/programs/drift/src/math/amm.rs
+++ b/programs/drift/src/math/amm.rs
@@ -430,6 +430,10 @@ pub fn update_oracle_price_twap(
         amm.historical_oracle_data.last_oracle_price = oracle_price_data.price;
         amm.last_oracle_conf_pct = oracle_price_data
             .confidence
+            .max(
+                amm.last_oracle_conf_pct
+                    .safe_sub(amm.last_oracle_conf_pct / 5)?,
+            )
             .safe_mul(BID_ASK_SPREAD_PRECISION)?
             .safe_div(reserve_price)? as u64;
         amm.historical_oracle_data.last_oracle_delay = oracle_price_data.delay;

--- a/programs/drift/src/math/amm.rs
+++ b/programs/drift/src/math/amm.rs
@@ -431,7 +431,7 @@ pub fn update_oracle_price_twap(
 
         // use decayed last_oracle_conf_pct as lower bound
         amm.last_oracle_conf_pct =
-            amm.update_last_oracle_conf_pct(oracle_price_data.confidence, reserve_price, now)?;
+            amm.get_new_oracle_conf_pct(oracle_price_data.confidence, reserve_price, now)?;
 
         amm.historical_oracle_data.last_oracle_delay = oracle_price_data.delay;
         amm.last_oracle_reserve_price_spread_pct =

--- a/programs/drift/src/math/amm_spread.rs
+++ b/programs/drift/src/math/amm_spread.rs
@@ -332,9 +332,10 @@ pub fn calculate_spread(
     let mut long_spread = max(half_base_spread_u64, long_vol_spread);
     let mut short_spread = max(half_base_spread_u64, short_vol_spread);
 
-    let max_target_spread = max_spread
-        .cast::<u64>()?
-        .max(last_oracle_reserve_price_spread_pct.unsigned_abs());
+    // todo add more baselines for max spread to increase
+    let max_spread_baseline = last_oracle_reserve_price_spread_pct.unsigned_abs();
+
+    let max_target_spread = max_spread.cast::<u64>()?.max(max_spread_baseline);
 
     // oracle retreat
     // if mark - oracle < 0 (mark below oracle) and user going long then increase spread

--- a/programs/drift/src/state/perp_market.rs
+++ b/programs/drift/src/state/perp_market.rs
@@ -1144,8 +1144,8 @@ impl AMM {
         Ok(())
     }
 
-    pub fn update_last_oracle_conf_pct(
-        &mut self,
+    pub fn get_new_oracle_conf_pct(
+        &self,
         confidence: u64,    // price precision
         reserve_price: u64, // price precision
         now: i64,
@@ -1160,7 +1160,7 @@ impl AMM {
         let confidence_lower_bound = if since_last > 0 {
             let confidence_divisor = upper_bound_divisor
                 .saturating_sub(since_last.cast::<u64>()?)
-                .clamp(lower_bound_divisor, upper_bound_divisor);
+                .max(lower_bound_divisor);
             self.last_oracle_conf_pct
                 .safe_sub(self.last_oracle_conf_pct / confidence_divisor)?
         } else {


### PR DESCRIPTION
a single confidence point from pyth oracle can be too tight. 

> One example scenario is if all publishers/active quotes are tight/close to each other during a 25 slot window the confidence will be normal (tight in our case here)

small change to smooth confidence numbers 