### PR TITLE
BUGFIX: Removing unnecessary duplicate send from FastSingleTxSender

### DIFF
--- a/sdk/src/tx/fastSingleTxSender.ts
+++ b/sdk/src/tx/fastSingleTxSender.ts
@@ -145,11 +145,6 @@ export class FastSingleTxSender extends BaseTxSender {
 			throw e;
 		}
 
-		this.connection.sendRawTransaction(rawTransaction, opts).catch((e) => {
-			console.error(e);
-		});
-		this.sendToAdditionalConnections(rawTransaction, opts);
-
 		let slot: number;
 		if (!this.skipConfirmation) {
 			try {


### PR DESCRIPTION
FastSingleTx sender was sending the transaction twice for some unclear reason, both to the main connection and through the additional connections. I've removed the duplicated behavior.