### PR TITLE
Added handling for uncrossing bug reported by user

### DIFF
--- a/sdk/src/dlob/orderBookLevels.ts
+++ b/sdk/src/dlob/orderBookLevels.ts
@@ -430,6 +430,30 @@ function groupL2Levels(
 }
 
 /**
+ * Method to merge bids or asks by price
+ */
+const mergeByPrice = (bidsOrAsks: L2Level[]) => {
+	const merged = new Map<string, L2Level>();
+	for (const level of bidsOrAsks) {
+		const key = level.price.toString();
+		if (merged.has(key)) {
+			const existing = merged.get(key);
+			existing.size = existing.size.add(level.size);
+			for (const [source, size] of Object.entries(level.sources)) {
+				if (existing.sources[source]) {
+					existing.sources[source] = existing.sources[source].add(size);
+				} else {
+					existing.sources[source] = size;
+				}
+			}
+		} else {
+			merged.set(key, cloneL2Level(level));
+		}
+	}
+	return Array.from(merged.values());
+};
+
+/**
  * The purpose of this function is uncross the L2 orderbook by modifying the bid/ask price at the top of the book
  * This will make the liquidity look worse but more intuitive (users familiar with clob get confused w temporarily
  * crossing book)
@@ -467,8 +491,8 @@ export function uncrossL2(
 		return { bids, asks };
 	}
 
-	const newBids = [];
-	const newAsks = [];
+	const newBids: L2Level[] = [];
+	const newAsks: L2Level[] = [];
 
 	const updateLevels = (newPrice: BN, oldLevel: L2Level, levels: L2Level[]) => {
 		if (levels.length > 0 && levels[levels.length - 1].price.eq(newPrice)) {
@@ -528,19 +552,19 @@ export function uncrossL2(
 			continue;
 		}
 
+		if (userBids.has(nextBid.price.toString())) {
+			newBids.push(nextBid);
+			bidIndex++;
+			continue;
+		}
+
+		if (userAsks.has(nextAsk.price.toString())) {
+			newAsks.push(nextAsk);
+			askIndex++;
+			continue;
+		}
+
 		if (nextBid.price.gte(nextAsk.price)) {
-			if (userBids.has(nextBid.price.toString())) {
-				newBids.push(nextBid);
-				bidIndex++;
-				continue;
-			}
-
-			if (userAsks.has(nextAsk.price.toString())) {
-				newAsks.push(nextAsk);
-				askIndex++;
-				continue;
-			}
-
 			if (
 				nextBid.price.gt(referencePrice) &&
 				nextAsk.price.gt(referencePrice)
@@ -594,8 +618,14 @@ export function uncrossL2(
 		}
 	}
 
+	newBids.sort((a, b) => b.price.cmp(a.price));
+	newAsks.sort((a, b) => a.price.cmp(b.price));
+
+	const finalNewBids = mergeByPrice(newBids);
+	const finalNewAsks = mergeByPrice(newAsks);
+
 	return {
-		bids: newBids,
-		asks: newAsks,
+		bids: finalNewBids,
+		asks: finalNewAsks,
 	};
 }

--- a/sdk/tests/dlob/test.ts
+++ b/sdk/tests/dlob/test.ts
@@ -6614,6 +6614,63 @@ describe('Uncross L2', () => {
 		);
 	});
 
+	it('Handles user crossing bid in second level', () => {
+		const oraclePrice = new BN(190.3843 * PRICE_PRECISION.toNumber());
+		const bids = [
+			[190.59, 2],
+			[190.588, 58.3],
+			[190.5557, 5],
+			[190.5547, 5],
+			[190.5508, 5],
+			[190.541, 2],
+			[190.5099, 49.1],
+			[190.5, 60],
+		].map(([price, size]) => ({
+			price: new BN(price * PRICE_PRECISION.toNumber()),
+			size: new BN(size * BASE_PRECISION.toNumber()),
+			sources: { vamm: new BN(size * BASE_PRECISION.toNumber()) },
+		}));
+
+		const asks = [
+			[190.5, 86.5],
+			[190.6159, 1],
+			[190.656, 10.5],
+			[190.6561, 1],
+			[190.6585, 5],
+			[190.6595, 5],
+			[190.6596, 5],
+		].map(([price, size]) => ({
+			price: new BN(price * PRICE_PRECISION.toNumber()),
+			size: new BN(size * BASE_PRECISION.toNumber()),
+			sources: { vamm: new BN(size * BASE_PRECISION.toNumber()) },
+		}));
+
+		expect(asksAreSortedAsc(asks), 'Input asks are ascending').to.be.true;
+		expect(bidsAreSortedDesc(bids), 'Input bids are descending').to.be.true;
+
+		const groupingSize = new BN('100');
+
+		const userBidPrice = new BN(190.588 * PRICE_PRECISION.toNumber());
+		const userBids = new Set<string>([userBidPrice.toString()]);
+
+		const { bids: newBids, asks: newAsks } = uncrossL2(
+			bids,
+			asks,
+			oraclePrice,
+			oraclePrice,
+			oraclePrice,
+			groupingSize,
+			userBids,
+			new Set<string>()
+		);
+
+		expect(asksAreSortedAsc(newAsks), 'Uncrossed asks are ascending').to.be
+			.true;
+		expect(bidsAreSortedDesc(newBids), 'Uncrossed bids are descending').to.be
+			.true;
+		expect(newBids[0].price.toString()).to.equal(userBidPrice.toString());
+	});
+
 	it('Handles edge case bide and asks with large cross and an overlapping level', () => {
 		const bids = [
 			'104411000',


### PR DESCRIPTION
Fixes an uncrossing bug reported by user. Added test to confirm. You can see the situation in the following screenshots:

1: User's bid is in the second level - 190.588
<img width="457" alt="image" src="https://github.com/drift-labs/protocol-v2/assets/14064888/a70793c0-083d-4cba-af01-6acca7859c3b">

2: Crossing ask comes in at 190.5, user's bid disappears (and TWO 190.499 levels get created)
<img width="471" alt="image" src="https://github.com/drift-labs/protocol-v2/assets/14064888/ad7e9071-1cc5-4f0f-8736-33b0180a9113">

I added a test with levels exactly matching the screenshot below. Without the changes to the uncrossL2 method that I added, you will see that it fails.