### PR TITLE
program: fix-track-unsettled-quote-for-lp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- program: fix tracking unsettled quote for lp ([#1026](https://github.com/drift-labs/protocol-v2/pull/1026))
+
 ### Breaking
 
 ## [2.78.0] - 2024-04-20

--- a/programs/drift/src/controller/position.rs
+++ b/programs/drift/src/controller/position.rs
@@ -6,7 +6,7 @@ use crate::controller;
 use crate::controller::amm::SwapDirection;
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::casting::Cast;
-use crate::math::constants::{MAX_BASE_ASSET_AMOUNT_WITH_AMM, PERP_DECIMALS, QUOTE_PRECISION_I128};
+use crate::math::constants::{MAX_BASE_ASSET_AMOUNT_WITH_AMM, PERP_DECIMALS};
 use crate::math::orders::{
     calculate_quote_asset_amount_for_maker_order, get_position_delta_for_fill,
     is_multiple_of_step_size,
@@ -446,7 +446,7 @@ pub fn update_lp_market_position(
         .calculate_lp_base_delta(per_lp_delta_base, base_unit)?;
     let lp_delta_quote = market
         .amm
-        .calculate_lp_base_delta(per_lp_delta_quote, QUOTE_PRECISION_I128)?;
+        .calculate_lp_base_delta(per_lp_delta_quote, base_unit)?;
 
     market.amm.base_asset_amount_with_amm = market
         .amm

--- a/programs/drift/src/state/perp_market.rs
+++ b/programs/drift/src/state/perp_market.rs
@@ -512,6 +512,11 @@ impl PerpMarket {
                 .amm
                 .base_asset_amount_with_unsettled_lp
                 .safe_add(new_settled_base_asset_amount.cast()?)?;
+
+            self.amm.quote_asset_amount_with_unsettled_lp = self
+                .amm
+                .quote_asset_amount_with_unsettled_lp
+                .safe_add(delta.quote_asset_amount.cast()?)?;
         }
 
         Ok(())


### PR DESCRIPTION
- solves incorrect cost basis for determining settle_pnl when market has high lp turnover + prolonged unsettled
- doesnt impact lp mathematics, just accounting maths for determining safe settle_pnl
- includes cargo test