### PR TITLE
ts-sdk: allow override isOrderExpired buffer

### DIFF
--- a/sdk/src/dlob/DLOB.ts
+++ b/sdk/src/dlob/DLOB.ts
@@ -985,7 +985,7 @@ export class DLOB {
 
 		for (const bidGenerator of bidGenerators) {
 			for (const bid of bidGenerator) {
-				if (isOrderExpired(bid.order, ts, true)) {
+				if (isOrderExpired(bid.order, ts, true, 25)) {
 					nodesToFill.push({
 						node: bid,
 						makerNodes: [],
@@ -996,7 +996,7 @@ export class DLOB {
 
 		for (const askGenerator of askGenerators) {
 			for (const ask of askGenerator) {
-				if (isOrderExpired(ask.order, ts, true)) {
+				if (isOrderExpired(ask.order, ts, true, 25)) {
 					nodesToFill.push({
 						node: ask,
 						makerNodes: [],

--- a/sdk/src/math/orders.ts
+++ b/sdk/src/math/orders.ts
@@ -287,7 +287,8 @@ function isSameDirection(
 export function isOrderExpired(
 	order: Order,
 	ts: number,
-	enforceBuffer = false
+	enforceBuffer = false,
+	bufferSeconds = 15
 ): boolean {
 	if (
 		mustBeTriggered(order) ||
@@ -299,7 +300,7 @@ export function isOrderExpired(
 
 	let maxTs;
 	if (enforceBuffer && isLimitOrder(order)) {
-		maxTs = order.maxTs.addn(15);
+		maxTs = order.maxTs.addn(bufferSeconds);
 	} else {
 		maxTs = order.maxTs;
 	}


### PR DESCRIPTION
Allow user to override the buffer in `isOrderExpired` to account for blockchain clock drift