### PR TITLE
sdk: make TxSender backwards compatible

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -78,6 +78,7 @@ export * from './tx/whileValidTxSender';
 export * from './tx/priorityFeeCalculator';
 export * from './tx/forwardOnlyTxSender';
 export * from './tx/types';
+export * from './tx/txHandler';
 export * from './util/computeUnits';
 export * from './util/tps';
 export * from './util/promiseTimeout';

--- a/sdk/src/tx/types.ts
+++ b/sdk/src/tx/types.ts
@@ -1,7 +1,9 @@
 import {
+	AddressLookupTableAccount,
 	ConfirmOptions,
 	Signer,
 	Transaction,
+	TransactionInstruction,
 	TransactionSignature,
 	VersionedTransaction,
 } from '@solana/web3.js';
@@ -34,6 +36,14 @@ export interface TxSender {
 		opts?: ConfirmOptions,
 		preSigned?: boolean
 	): Promise<TxSigAndSlot>;
+
+	getVersionedTransaction(
+		ixs: TransactionInstruction[],
+		lookupTableAccounts: AddressLookupTableAccount[],
+		additionalSigners?: Array<Signer>,
+		opts?: ConfirmOptions,
+		blockhash?: string
+	): Promise<VersionedTransaction>;
 
 	sendRawTransaction(
 		rawTransaction: Buffer | Uint8Array,


### PR DESCRIPTION
* gives `TxSender` a default `TxHandler`
* bring back `getVersionedTransaction` on `TxSender` to maintain backwards compatibility