### PR TITLE
sdk: TxSender use generateVersionedTransaction for get tx

### DIFF
--- a/sdk/src/tx/baseTxSender.ts
+++ b/sdk/src/tx/baseTxSender.ts
@@ -17,6 +17,7 @@ import {
 	VersionedTransaction,
 	TransactionInstruction,
 	AddressLookupTableAccount,
+	BlockhashWithExpiryBlockHeight,
 } from '@solana/web3.js';
 import { AnchorProvider } from '@coral-xyz/anchor';
 import assert from 'assert';
@@ -116,17 +117,14 @@ export abstract class BaseTxSender implements TxSender {
 		lookupTableAccounts: AddressLookupTableAccount[],
 		_additionalSigners?: Array<Signer>,
 		opts?: ConfirmOptions,
-		_blockhash?: string
+		blockhash?: BlockhashWithExpiryBlockHeight
 	): Promise<VersionedTransaction> {
-		return (await this.txHandler.buildTransaction({
-			connection: this.connection,
-			instructions: ixs,
-			fetchMarketLookupTableAccount: undefined,
-			lookupTables: lookupTableAccounts,
-			preFlightCommitment: opts?.commitment ?? 'confirmed',
-			txVersion: 0,
-			forceVersionedTransaction: true,
-		})) as VersionedTransaction;
+		return this.txHandler.generateVersionedTransaction(
+			blockhash,
+			ixs,
+			lookupTableAccounts,
+			this.wallet
+		);
 	}
 
 	async sendVersionedTransaction(

--- a/sdk/src/tx/types.ts
+++ b/sdk/src/tx/types.ts
@@ -1,5 +1,6 @@
 import {
 	AddressLookupTableAccount,
+	BlockhashWithExpiryBlockHeight,
 	ConfirmOptions,
 	Signer,
 	Transaction,
@@ -42,7 +43,7 @@ export interface TxSender {
 		lookupTableAccounts: AddressLookupTableAccount[],
 		additionalSigners?: Array<Signer>,
 		opts?: ConfirmOptions,
-		blockhash?: string
+		blockhash?: BlockhashWithExpiryBlockHeight
 	): Promise<VersionedTransaction>;
 
 	sendRawTransaction(

--- a/sdk/src/util/computeUnits.ts
+++ b/sdk/src/util/computeUnits.ts
@@ -1,4 +1,10 @@
-import { Connection, Finality, PublicKey } from '@solana/web3.js';
+import {
+	ComputeBudgetProgram,
+	Connection,
+	Finality,
+	PublicKey,
+	TransactionInstruction,
+} from '@solana/web3.js';
 
 export async function findComputeUnitConsumption(
 	programId: PublicKey,
@@ -18,4 +24,40 @@ export async function findComputeUnitConsumption(
 		}
 	});
 	return computeUnits;
+}
+
+export function isSetComputeUnitsIx(ix: TransactionInstruction): boolean {
+	// Compute budget program discriminator is first byte
+	// 2: set compute unit limit
+	// 3: set compute unit price
+	if (
+		ix.programId.equals(ComputeBudgetProgram.programId) &&
+		ix.data.at(0) === 2
+	) {
+		return true;
+	}
+	return false;
+}
+
+export function isSetComputeUnitPriceIx(ix: TransactionInstruction): boolean {
+	// Compute budget program discriminator is first byte
+	// 2: set compute unit limit
+	// 3: set compute unit price
+	if (
+		ix.programId.equals(ComputeBudgetProgram.programId) &&
+		ix.data.at(0) === 3
+	) {
+		return true;
+	}
+	return false;
+}
+
+export function containsComputeUnitIxs(ixs: TransactionInstruction[]): {
+	hasSetComputeUnitLimitIx: boolean;
+	hasSetComputeUnitPriceIx: boolean;
+} {
+	return {
+		hasSetComputeUnitLimitIx: ixs.some(isSetComputeUnitsIx),
+		hasSetComputeUnitPriceIx: ixs.some(isSetComputeUnitPriceIx),
+	};
 }


### PR DESCRIPTION
`buildTransaction` has some assumptions on priority fee ixs, this uses `generateVersionedTransaction` instead in `TxSender`. Downstream clients will need to make sure update blockhash+height passed instead of just blockhash

Make `buildTransaction` safer by being aware of existing instructions, and properly handling undefined `TxParams`