### PR TITLE
latestBlockchash on whileValidTxSender.prepareTx should be mutable

### DIFF
--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -79,7 +79,7 @@ export class WhileValidTxSender extends BaseTxSender {
 		opts: ConfirmOptions,
 		preSigned?: boolean
 	): Promise<Transaction> {
-		const latestBlockhash =
+		let latestBlockhash =
 			await this.txHandler.getLatestBlockhashForTransaction();
 
 		// handle tx


### PR DESCRIPTION
I do realize there's a @ts-ignore when it gets assigned later, but I am getting an error when attempting to use 2.84.0-beta.2 with bun 1.1.13, which seems to be more strict.

```
error: script "prod" exited with code 1
$ bun run src/index.ts --config-file uncross.config.yaml
45 |             latestBlockhash = tx.SIGNATURE_BLOCK_AND_EXPIRY;
                 ^
error: This assignment will throw because "latestBlockhash" is a constant
    at keeper-bots-v2/node_modules/@drift-labs/sdk/lib/tx/whileValidTxSender.js:45:13

35 |         const latestBlockhash = await this.txHandler.getLatestBlockhashForTransaction();
                   ^
note: The symbol "latestBlockhash" was declared a constant here:
   at keeper-bots-v2/node_modules/@drift-labs/sdk/lib/tx/whileValidTxSender.js:35:15
```