### PR TITLE
Update openbook_v2.rs

### DIFF
--- a/programs/openbook_v2/src/account.rs
+++ b/programs/openbook_v2/src/account.rs
@@ -176,8 +176,7 @@ impl BookSide {
         let mut p = 0_u64;
         for node in self.nodes.nodes.iter() {
             if node.tag == LEAF_NODE_TAG {
-                let leaf_node = LeafNode::try_from_slice(&node.try_to_vec().unwrap()).unwrap();
-                let price = leaf_node.price_data();
+                let price = (u128::try_from_slice(&node.data[7..23]).unwrap() >> 64) as u64;
                 if price < p || p == 0 {
                     p = price;
                 }
@@ -194,8 +193,7 @@ impl BookSide {
         let mut p = 0_u64;
         for node in self.nodes.nodes.iter() {
             if node.tag == LEAF_NODE_TAG {
-                let leaf_node = LeafNode::try_from_slice(&node.try_to_vec().unwrap()).unwrap();
-                let price = leaf_node.price_data();
+                let price = (u128::try_from_slice(&node.data[7..23]).unwrap() >> 64) as u64;
                 if price > p {
                     p = price;
                 }

--- a/programs/openbook_v2/src/context.rs
+++ b/programs/openbook_v2/src/context.rs
@@ -24,3 +24,8 @@ pub struct CreateOpenOrdersAccount<'info> {
 pub struct PlaceOrder<'info> {
     pub dummy_authority: Signer<'info>,
 }
+
+#[derive(Accounts)]
+pub struct ConsumeEvents<'info> {
+    pub dummy_authority: Signer<'info>,
+}

--- a/programs/openbook_v2/src/lib.rs
+++ b/programs/openbook_v2/src/lib.rs
@@ -73,4 +73,11 @@ mod openbook_v2 {
     ) -> Result<()> {
         Ok(())
     }
+
+    pub(crate) fn consume_events(
+        ctx: Context<ConsumeEvents>,
+        limit: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
removed ability to add openbooks OOAs - cranking can be solved as adding instruction - consume_events or in jito bundles as separate transaction.

the copying code from https://github.com/cavemanloverboy/solana-invoke is solving some ( or all?) out of memory errors which occurs after invoking openbook's place_take_order