### PR TITLE
Minor changes for DLOB / OrderSubscriber subclassing

### DIFF
--- a/sdk/src/dlob/DLOB.ts
+++ b/sdk/src/dlob/DLOB.ts
@@ -1104,7 +1104,7 @@ export class DLOB {
 		);
 	}
 
-	private *getBestNode(
+	protected *getBestNode(
 		generatorList: Array<Generator<DLOBNode>>,
 		oraclePriceData: OraclePriceData,
 		slot: number,

--- a/sdk/src/orderSubscriber/OrderSubscriber.ts
+++ b/sdk/src/orderSubscriber/OrderSubscriber.ts
@@ -217,8 +217,17 @@ export class OrderSubscriber {
 		}
 	}
 
+	/**
+	 * Creates a new DLOB for the order subscriber to fill. This will allow a
+	 * caller to extend the DLOB Subscriber with a custom DLOB type.
+	 * @returns New, empty DLOB object.
+	 */
+	protected createDLOB(): DLOB {
+		return new DLOB();
+	}
+
 	public async getDLOB(slot: number): Promise<DLOB> {
-		const dlob = new DLOB();
+		const dlob = this.createDLOB();
 		for (const [key, { userAccount }] of this.usersAccounts.entries()) {
 			for (const order of userAccount.orders) {
 				dlob.insertOrder(order, key, slot);


### PR DESCRIPTION
- DLOB's getBestNode generation is now protected, so that subclasses can access it.
- OrderSubscriber can be subclassed to create a different subclass of DLOB object.