### PR TITLE
Fix `Dockerfile` for dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 # is released on GitHub.
 #
 
-FROM ubuntu:22.04
+FROM rust:1.75
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
The dev container is broken. I think this is from a later version of Rust, as it seems to work once we change from Ubuntu to Rust 1.75. I didn't test that it works on this repo, but I tested that it works [here](https://github.com/metaDAOproject/futarchy/blob/develop/.devcontainer/Dockerfile).