### PR TITLE
program: remove redundant clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- program: remove redundant clones ([#1199](https://github.com/drift-labs/protocol-v2/pull/1199))
+
 ### Breaking
 
 ## [2.93.0] - 2024-08-22

--- a/programs/drift/src/controller/token.rs
+++ b/programs/drift/src/controller/token.rs
@@ -24,15 +24,15 @@ pub fn send_from_program_vault<'info>(
     let signers = &[&signature_seeds[..]];
 
     if let Some(mint) = mint {
-        let mint_account_info = mint.to_account_info().clone();
+        let mint_account_info = mint.to_account_info();
 
         validate_mint_fee(&mint_account_info)?;
 
         let cpi_accounts = TransferChecked {
-            from: from.to_account_info().clone(),
+            from: from.to_account_info(),
             mint: mint_account_info,
-            to: to.to_account_info().clone(),
-            authority: authority.to_account_info().clone(),
+            to: to.to_account_info(),
+            authority: authority.to_account_info(),
         };
 
         let cpi_program = token_program.to_account_info();
@@ -40,9 +40,9 @@ pub fn send_from_program_vault<'info>(
         token_interface::transfer_checked(cpi_context, amount, mint.decimals)
     } else {
         let cpi_accounts = Transfer {
-            from: from.to_account_info().clone(),
-            to: to.to_account_info().clone(),
-            authority: authority.to_account_info().clone(),
+            from: from.to_account_info(),
+            to: to.to_account_info(),
+            authority: authority.to_account_info(),
         };
 
         let cpi_program = token_program.to_account_info();
@@ -61,24 +61,24 @@ pub fn receive<'info>(
     mint: &Option<InterfaceAccount<'info, Mint>>,
 ) -> Result<()> {
     if let Some(mint) = mint {
-        let mint_account_info = mint.to_account_info().clone();
+        let mint_account_info = mint.to_account_info();
 
         validate_mint_fee(&mint_account_info)?;
 
         let cpi_accounts = TransferChecked {
-            from: from.to_account_info().clone(),
-            to: to.to_account_info().clone(),
+            from: from.to_account_info(),
+            to: to.to_account_info(),
             mint: mint_account_info,
-            authority: authority.to_account_info().clone(),
+            authority: authority.to_account_info(),
         };
         let cpi_program = token_program.to_account_info();
         let cpi_context = CpiContext::new(cpi_program, cpi_accounts);
         token_interface::transfer_checked(cpi_context, amount, mint.decimals)
     } else {
         let cpi_accounts = Transfer {
-            from: from.to_account_info().clone(),
-            to: to.to_account_info().clone(),
-            authority: authority.to_account_info().clone(),
+            from: from.to_account_info(),
+            to: to.to_account_info(),
+            authority: authority.to_account_info(),
         };
         let cpi_program = token_program.to_account_info();
         let cpi_context = CpiContext::new(cpi_program, cpi_accounts);
@@ -97,9 +97,9 @@ pub fn close_vault<'info>(
     let signature_seeds = get_signer_seeds(&nonce);
     let signers = &[&signature_seeds[..]];
     let cpi_accounts = CloseAccount {
-        account: account.to_account_info().clone(),
+        account: account.to_account_info(),
         destination: destination.clone(),
-        authority: authority.to_account_info().clone(),
+        authority: authority.to_account_info(),
     };
     let cpi_program = token_program.to_account_info();
     let cpi_context = CpiContext::new_with_signer(cpi_program, cpi_accounts, signers);

--- a/programs/drift/src/instructions/admin.rs
+++ b/programs/drift/src/instructions/admin.rs
@@ -4028,12 +4028,12 @@ pub fn handle_initialize_pyth_pull_oracle(
     ctx: Context<InitPythPullPriceFeed>,
     feed_id: [u8; 32],
 ) -> Result<()> {
-    let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info().clone();
+    let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info();
     let cpi_accounts = InitPriceUpdate {
-        payer: ctx.accounts.admin.to_account_info().clone(),
-        price_update_account: ctx.accounts.price_feed.to_account_info().clone(),
-        system_program: ctx.accounts.system_program.to_account_info().clone(),
-        write_authority: ctx.accounts.price_feed.to_account_info().clone(),
+        payer: ctx.accounts.admin.to_account_info(),
+        price_update_account: ctx.accounts.price_feed.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        write_authority: ctx.accounts.price_feed.to_account_info(),
     };
 
     let seeds = &[

--- a/programs/drift/src/instructions/pyth_pull_oracle.rs
+++ b/programs/drift/src/instructions/pyth_pull_oracle.rs
@@ -20,12 +20,12 @@ pub fn handle_update_pyth_pull_oracle(
     feed_id: [u8; 32],
     params: Vec<u8>,
 ) -> Result<()> {
-    let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info().clone();
+    let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info();
     let cpi_accounts = PostUpdate {
-        payer: ctx.accounts.keeper.to_account_info().clone(),
-        encoded_vaa: ctx.accounts.encoded_vaa.to_account_info().clone(),
-        price_update_account: ctx.accounts.price_feed.to_account_info().clone(),
-        write_authority: ctx.accounts.price_feed.to_account_info().clone(),
+        payer: ctx.accounts.keeper.to_account_info(),
+        encoded_vaa: ctx.accounts.encoded_vaa.to_account_info(),
+        price_update_account: ctx.accounts.price_feed.to_account_info(),
+        write_authority: ctx.accounts.price_feed.to_account_info(),
     };
 
     let seeds = &[
@@ -66,12 +66,12 @@ pub fn handle_post_pyth_pull_oracle_update_atomic(
     feed_id: [u8; 32],
     params: Vec<u8>,
 ) -> Result<()> {
-    let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info().clone();
+    let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info();
     let cpi_accounts = PostUpdateAtomic {
-        payer: ctx.accounts.keeper.to_account_info().clone(),
-        guardian_set: ctx.accounts.guardian_set.to_account_info().clone(),
-        price_update_account: ctx.accounts.price_feed.to_account_info().clone(),
-        write_authority: ctx.accounts.price_feed.to_account_info().clone(),
+        payer: ctx.accounts.keeper.to_account_info(),
+        guardian_set: ctx.accounts.guardian_set.to_account_info(),
+        price_update_account: ctx.accounts.price_feed.to_account_info(),
+        write_authority: ctx.accounts.price_feed.to_account_info(),
     };
 
     let seeds = &[
@@ -139,10 +139,10 @@ pub fn handle_post_multi_pyth_pull_oracle_updates_atomic<'c: 'info, 'info>(
 
     for (account, merkle_price_update) in remaining_accounts.iter().zip(merkle_price_updates.iter())
     {
-        let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info().clone();
+        let cpi_program = ctx.accounts.pyth_solana_receiver.to_account_info();
         let cpi_accounts = PostUpdateAtomic {
-            payer: ctx.accounts.keeper.to_account_info().clone(),
-            guardian_set: ctx.accounts.guardian_set.to_account_info().clone(),
+            payer: ctx.accounts.keeper.to_account_info(),
+            guardian_set: ctx.accounts.guardian_set.to_account_info(),
             price_update_account: account.clone(),
             write_authority: account.clone(),
         };

--- a/programs/drift/src/instructions/user.rs
+++ b/programs/drift/src/instructions/user.rs
@@ -185,9 +185,9 @@ pub fn handle_initialize_user<'c: 'info, 'info>(
                 init_fee,
             ),
             &[
-                ctx.accounts.payer.to_account_info().clone(),
-                ctx.accounts.user.to_account_info().clone(),
-                ctx.accounts.system_program.to_account_info().clone(),
+                ctx.accounts.payer.to_account_info(),
+                ctx.accounts.user.to_account_info(),
+                ctx.accounts.system_program.to_account_info(),
             ],
         )?;
     }

--- a/programs/drift/src/state/fulfillment_params/serum.rs
+++ b/programs/drift/src/state/fulfillment_params/serum.rs
@@ -117,7 +117,7 @@ impl<'a, 'b> SerumContext<'a, 'b> {
             self.serum_open_orders.clone(),
             authority.clone(),
             self.serum_market.clone(),
-            rent.to_account_info().clone(),
+            rent.to_account_info(),
         ];
         solana_program::program::invoke_signed(&instruction, &account_infos, signers_seeds).map_err(
             |e| {


### PR DESCRIPTION
### Problem

`to_account_info().clone()` is an anti-pattern because [`to_account_info`](https://github.com/coral-xyz/anchor/blob/84fdf31d58f4683e810967cffa941013af1dec94/lang/src/lib.rs#L169) already returns an owned `AccountInfo`.

### Summary of changes

Remove the redundant `clone()` call from `to_account_info().clone()`s.