### PR TITLE
Luke/dpe 2216 remove deprecating rpc methods

### DIFF
--- a/sdk/src/tx/baseTxSender.ts
+++ b/sdk/src/tx/baseTxSender.ts
@@ -267,10 +267,9 @@ export abstract class BaseTxSender implements TxSender {
 		if (response === null) {
 			if (this.confirmationStrategy === ConfirmationStrategy.Combo) {
 				try {
-
-					const rpcResponse = await this.connection.getSignatureStatuses(
-						[signature]
-					);
+					const rpcResponse = await this.connection.getSignatureStatuses([
+						signature,
+					]);
 
 					if (rpcResponse?.value?.[0]?.confirmationStatus) {
 						response = {
@@ -307,13 +306,17 @@ export abstract class BaseTxSender implements TxSender {
 		while (totalTime < this.timeout) {
 			await new Promise((resolve) => setTimeout(resolve, backoffTime));
 
-			const rpcResponse = await this.connection.getSignatureStatuses(
-				[signature]
-			);
+			const rpcResponse = await this.connection.getSignatureStatuses([
+				signature,
+			]);
 
 			const signatureResult = rpcResponse && rpcResponse.value?.[0];
 
-			if (rpcResponse && signatureResult && signatureResult.confirmationStatus === commitment) {
+			if (
+				rpcResponse &&
+				signatureResult &&
+				signatureResult.confirmationStatus === commitment
+			) {
 				return { context: rpcResponse.context, value: { err: null } };
 			}
 

--- a/sdk/src/tx/fastSingleTxSender.ts
+++ b/sdk/src/tx/fastSingleTxSender.ts
@@ -118,14 +118,14 @@ export class FastSingleTxSender extends BaseTxSender {
 					this.confirmTransaction(txid, opts.commitment).then(
 						async (result) => {
 							this.txSigCache?.set(txid, true);
-							await this.checkConfirmationResultForError(txid, result);
+							await this.checkConfirmationResultForError(txid, result.value);
 							slot = result.context.slot;
 						}
 					);
 				} else {
 					const result = await this.confirmTransaction(txid, opts.commitment);
 					this.txSigCache?.set(txid, true);
-					await this.checkConfirmationResultForError(txid, result);
+					await this.checkConfirmationResultForError(txid, result.value);
 					slot = result.context.slot;
 				}
 			} catch (e) {

--- a/sdk/src/tx/retryTxSender.ts
+++ b/sdk/src/tx/retryTxSender.ts
@@ -117,7 +117,7 @@ export class RetryTxSender extends BaseTxSender {
 			const result = await this.confirmTransaction(txid, opts.commitment);
 			this.txSigCache?.set(txid, true);
 
-			await this.checkConfirmationResultForError(txid, result);
+			await this.checkConfirmationResultForError(txid, result.value);
 
 			slot = result.context.slot;
 			// eslint-disable-next-line no-useless-catch

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -40,7 +40,18 @@ export class WhileValidTxSender extends BaseTxSender {
 	private async checkAndSetUseBlockHeightOffset() {
 		this.connection.getVersion().then((version) => {
 			const solanaCoreVersion = version['solana-core'];
-			if (parseInt(solanaCoreVersion.split('.')[0]) >= 2) {
+
+			if (!solanaCoreVersion) return;
+
+			const majorVersion = solanaCoreVersion.split('.')[0];
+
+			if (!majorVersion) return;
+
+			const parsedMajorVersion = parseInt(majorVersion);
+
+			if (isNaN(parsedMajorVersion)) return;
+
+			if (parsedMajorVersion >= 2) {
 				this.useBlockHeightOffset = false;
 			} else {
 				this.useBlockHeightOffset = true;

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -15,6 +15,8 @@ import { IWallet } from '../types';
 
 const DEFAULT_RETRY = 2000;
 
+const VALID_BLOCK_HEIGHT_OFFSET = -150; // This is a bit of weirdness but the lastValidBlockHeight value returned from connection.getLatestBlockhash is always 300 blocks ahead of the current block, even though the transaction actually expires after 150 blocks. This accounts for that so that we can at least accuractely estimate the transaction expiry.
+
 type ResolveReference = {
 	resolve?: () => void;
 };
@@ -211,17 +213,17 @@ export class WhileValidTxSender extends BaseTxSender {
 			const result = await this.connection.confirmTransaction({
 				signature: txid,
 				blockhash,
-				lastValidBlockHeight,
-			});
+				lastValidBlockHeight:
+						lastValidBlockHeight + VALID_BLOCK_HEIGHT_OFFSET,
+			}, opts?.commitment);
 
 			if (!result) {
 				throw new Error(`Couldn't get signature status for txid: ${txid}`);
 			}
 
-			const txsigResult = result.value;
-
 			this.txSigCache?.set(txid, true);
-			await this.checkConfirmationResultForError(txid, txsigResult);
+
+			await this.checkConfirmationResultForError(txid, result.value);
 
 			slot = result.context.slot;
 			// eslint-disable-next-line no-useless-catch

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -206,13 +206,19 @@ export class WhileValidTxSender extends BaseTxSender {
 
 		let slot: number;
 		try {
-			const result = await this.connection.getSignatureStatuses([txid]);
+			const { blockhash, lastValidBlockHeight } = this.untilValid.get(txid);
+
+			const result = await this.connection.confirmTransaction({
+				signature: txid,
+				blockhash,
+				lastValidBlockHeight,
+			});
 
 			if (!result) {
 				throw new Error(`Couldn't get signature status for txid: ${txid}`);
 			}
 
-			const txsigResult = result.value[0];
+			const txsigResult = result.value;
 
 			this.txSigCache?.set(txid, true);
 			await this.checkConfirmationResultForError(txid, txsigResult);

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -15,8 +15,6 @@ import { IWallet } from '../types';
 
 const DEFAULT_RETRY = 2000;
 
-const VALID_BLOCK_HEIGHT_OFFSET = -150; // This is a bit of weirdness but the lastValidBlockHeight value returned from connection.getLatestBlockhash is always 300 blocks ahead of the current block, even though the transaction actually expires after 150 blocks. This accounts for that so that we can at least accuractely estimate the transaction expiry.
-
 type ResolveReference = {
 	resolve?: () => void;
 };
@@ -214,8 +212,7 @@ export class WhileValidTxSender extends BaseTxSender {
 				{
 					signature: txid,
 					blockhash,
-					lastValidBlockHeight:
-						lastValidBlockHeight + VALID_BLOCK_HEIGHT_OFFSET,
+					lastValidBlockHeight: lastValidBlockHeight,
 				},
 				opts?.commitment
 			);

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -15,8 +15,6 @@ import { IWallet } from '../types';
 
 const DEFAULT_RETRY = 2000;
 
-const VALID_BLOCK_HEIGHT_OFFSET = -150; // This is a bit of weirdness but the lastValidBlockHeight value returned from connection.getLatestBlockhash is always 300 blocks ahead of the current block, even though the transaction actually expires after 150 blocks. This accounts for that so that we can at least accuractely estimate the transaction expiry.
-
 type ResolveReference = {
 	resolve?: () => void;
 };
@@ -208,18 +206,16 @@ export class WhileValidTxSender extends BaseTxSender {
 
 		let slot: number;
 		try {
-			const { blockhash, lastValidBlockHeight } = this.untilValid.get(txid);
-			const result = await this.connection.confirmTransaction(
-				{
-					signature: txid,
-					lastValidBlockHeight:
-						lastValidBlockHeight + VALID_BLOCK_HEIGHT_OFFSET,
-					blockhash,
-				},
-				opts.commitment
-			);
+			const result = await this.connection.getSignatureStatuses([txid]);
+
+			if (!result) {
+				throw new Error(`Couldn't get signature status for txid: ${txid}`);
+			}
+
+			const txsigResult = result.value[0];
+
 			this.txSigCache?.set(txid, true);
-			await this.checkConfirmationResultForError(txid, result);
+			await this.checkConfirmationResultForError(txid, txsigResult);
 
 			slot = result.context.slot;
 			// eslint-disable-next-line no-useless-catch

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -210,12 +210,15 @@ export class WhileValidTxSender extends BaseTxSender {
 		try {
 			const { blockhash, lastValidBlockHeight } = this.untilValid.get(txid);
 
-			const result = await this.connection.confirmTransaction({
-				signature: txid,
-				blockhash,
-				lastValidBlockHeight:
+			const result = await this.connection.confirmTransaction(
+				{
+					signature: txid,
+					blockhash,
+					lastValidBlockHeight:
 						lastValidBlockHeight + VALID_BLOCK_HEIGHT_OFFSET,
-			}, opts?.commitment);
+				},
+				opts?.commitment
+			);
 
 			if (!result) {
 				throw new Error(`Couldn't get signature status for txid: ${txid}`);

--- a/sdk/tests/ci/idl.ts
+++ b/sdk/tests/ci/idl.ts
@@ -1,7 +1,4 @@
-import {
-	DriftClient,
-	BulkAccountLoader,
-} from '../../src';
+import { DriftClient, BulkAccountLoader } from '../../src';
 import { Connection, Keypair } from '@solana/web3.js';
 import { Wallet, Program } from '@coral-xyz/anchor';
 import dotenv from 'dotenv';
@@ -40,10 +37,15 @@ describe('Verify IDL', function () {
 	});
 
 	it('verify idl', async () => {
-		const idl = await Program.fetchIdl(mainnetDriftClient.program.programId, mainnetDriftClient.provider);
+		const idl = await Program.fetchIdl(
+			mainnetDriftClient.program.programId,
+			mainnetDriftClient.provider
+		);
 
 		// anchor idl init seems to strip the metadata
-		idl["metadata"] = {"address":"dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH"};
+		idl['metadata'] = {
+			address: 'dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH',
+		};
 		const encodedMainnetIdl = JSON.stringify(idl);
 
 		const encodedSdkIdl = JSON.stringify(driftIDL);

--- a/sdk/tests/ci/verifyConstants.ts
+++ b/sdk/tests/ci/verifyConstants.ts
@@ -61,13 +61,14 @@ describe('Verify Constants', function () {
 		},
 	});
 
-	let lutAccounts : string[];
+	let lutAccounts: string[];
 
 	before(async () => {
 		await devnetDriftClient.subscribe();
 		await mainnetDriftClient.subscribe();
 
-		const lookupTable = await mainnetDriftClient.fetchMarketLookupTableAccount();
+		const lookupTable =
+			await mainnetDriftClient.fetchMarketLookupTableAccount();
 		lutAccounts = lookupTable.state.addresses.map((x) => x.toBase58());
 	});
 
@@ -113,10 +114,20 @@ describe('Verify Constants', function () {
 			);
 
 			const lutHasMarket = lutAccounts.includes(market.pubkey.toBase58());
-			assert(lutHasMarket, `Mainnet LUT is missing spot market ${market.marketIndex} pubkey ${market.pubkey.toBase58()}`);
+			assert(
+				lutHasMarket,
+				`Mainnet LUT is missing spot market ${
+					market.marketIndex
+				} pubkey ${market.pubkey.toBase58()}`
+			);
 
 			const lutHasMarketOracle = lutAccounts.includes(market.oracle.toBase58());
-			assert(lutHasMarketOracle, `Mainnet LUT is missing spot market ${market.marketIndex} oracle ${market.oracle.toBase58()}`);
+			assert(
+				lutHasMarketOracle,
+				`Mainnet LUT is missing spot market ${
+					market.marketIndex
+				} oracle ${market.oracle.toBase58()}`
+			);
 		}
 
 		const perpMarkets = mainnetDriftClient.getPerpMarketAccounts();
@@ -150,10 +161,22 @@ describe('Verify Constants', function () {
 			);
 
 			const lutHasMarket = lutAccounts.includes(market.pubkey.toBase58());
-			assert(lutHasMarket, `Mainnet LUT is missing perp market ${market.marketIndex} pubkey ${market.pubkey.toBase58()}`);
+			assert(
+				lutHasMarket,
+				`Mainnet LUT is missing perp market ${
+					market.marketIndex
+				} pubkey ${market.pubkey.toBase58()}`
+			);
 
-			const lutHasMarketOracle = lutAccounts.includes(market.amm.oracle.toBase58());
-			assert(lutHasMarketOracle, `Mainnet LUT is missing perp market ${market.marketIndex} oracle ${market.amm.oracle.toBase58()}`);
+			const lutHasMarketOracle = lutAccounts.includes(
+				market.amm.oracle.toBase58()
+			);
+			assert(
+				lutHasMarketOracle,
+				`Mainnet LUT is missing perp market ${
+					market.marketIndex
+				} oracle ${market.amm.oracle.toBase58()}`
+			);
 		}
 	});
 


### PR DESCRIPTION
Should close this issue : https://github.com/drift-labs/protocol-v2/issues/1193

see : https://github.com/anza-xyz/agave/wiki/Agave-v2.0-Transition-Guide#step-2-review-removed-rpc-endpoints-and-sdk-elements (note, confirmTransaction isn't actually deprecated - its interface has just changed)