### PR TITLE
program: fix spot market map in force_cancel_orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - program: remove redundant clones ([#1199](https://github.com/drift-labs/protocol-v2/pull/1199))
+- program: fix spot market map in force_cancel_orders ([#1209](https://github.com/drift-labs/protocol-v2/pull/1209))
 
 ### Breaking
 

--- a/programs/drift/src/instructions/keeper.rs
+++ b/programs/drift/src/instructions/keeper.rs
@@ -347,7 +347,7 @@ pub fn handle_force_cancel_orders<'c: 'info, 'info>(
     } = load_maps(
         &mut ctx.remaining_accounts.iter().peekable(),
         &MarketSet::new(),
-        &MarketSet::new(),
+        &get_writable_spot_market_set(QUOTE_SPOT_MARKET_INDEX),
         Clock::get()?.slot,
         None,
     )?;


### PR DESCRIPTION
Ensures quote market account is writeable in `spot_market_map`