### PR TITLE
Use higher rate limit Jupiter API

### DIFF
--- a/sdk/src/jupiter/jupiterClient.ts
+++ b/sdk/src/jupiter/jupiterClient.ts
@@ -225,7 +225,7 @@ export class JupiterClient {
 
 	constructor({ connection, url }: { connection: Connection; url?: string }) {
 		this.connection = connection;
-		this.url = url ?? 'https://quote-api.jup.ag';
+		this.url = url ?? 'https://public.jupiterapi.com';
 	}
 
 	/**


### PR DESCRIPTION
This PR adjusts the API provided for the Jupiter package. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits (up to 10 rps) along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. With that said, the API does take a small platform fee (0.2%) on swaps given the stability/rate limits/new markets it provides.

More details can be found on the site.