### PR TITLE
Remove delete user in `OrderSubscriber` on filled.

### DIFF
--- a/sdk/src/orderSubscriber/OrderSubscriber.ts
+++ b/sdk/src/orderSubscriber/OrderSubscriber.ts
@@ -209,11 +209,8 @@ export class OrderSubscriber {
 					dataType
 				);
 			}
-			if (userAccount.hasOpenOrder) {
-				this.usersAccounts.set(key, { slot, userAccount });
-			} else {
-				this.usersAccounts.delete(key);
-			}
+
+			this.usersAccounts.set(key, { slot, userAccount });
 		}
 	}
 


### PR DESCRIPTION
This can be problematic if account updates are received out of order, or `tryUpdateUserAccount` is invoked out of order. If an account update for a slot `t-1` is received for an order filled at slot `t`, then the `OrderSubscriber` will erroneously report the open order.