### PR TITLE
Remove delete user in fetch

### DIFF
--- a/sdk/src/orderSubscriber/OrderSubscriber.ts
+++ b/sdk/src/orderSubscriber/OrderSubscriber.ts
@@ -100,24 +100,14 @@ export class OrderSubscriber {
 
 			const slot: number = rpcResponseAndContext.context.slot;
 
-			const programAccountSet = new Set<string>();
 			for (const programAccount of rpcResponseAndContext.value) {
 				const key = programAccount.pubkey.toString();
-				programAccountSet.add(key);
 				this.tryUpdateUserAccount(
 					key,
 					'raw',
 					programAccount.account.data,
 					slot
 				);
-				// give event loop a chance to breathe
-				await new Promise((resolve) => setTimeout(resolve, 0));
-			}
-
-			for (const key of this.usersAccounts.keys()) {
-				if (!programAccountSet.has(key)) {
-					this.usersAccounts.delete(key);
-				}
 				// give event loop a chance to breathe
 				await new Promise((resolve) => setTimeout(resolve, 0));
 			}


### PR DESCRIPTION
This pr is similar to pr #1245. Issue is that it can cause incorrect slot updates. 
For example, a fetch operation results in a user with now no open orders. Subsequently, a slot update arrives prior to this fetch, which orderSubscriber then utilizes due to the user's deletion during the fetch process.
