### PR TITLE
Revert "chore: remove drift-competitions from downstream dependency"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,7 +253,7 @@ jobs:
           [
             "jit-proxy",
             "dlob-server",
-            "drift-vaults",
+            "drift-competitions",
             "drift-common"
           ]
     steps:


### PR DESCRIPTION
Reverts drift-labs/protocol-v2#1276