### PR TITLE
add `PERCENTAGE_PRECISION` import for fixing compilation issue

### DIFF
--- a/programs/drift/src/math/spot_balance.rs
+++ b/programs/drift/src/math/spot_balance.rs
@@ -5,6 +5,7 @@ use crate::math::safe_math::{SafeDivFloor, SafeMath};
 use crate::state::oracle::{OraclePriceData, StrictOraclePrice};
 use crate::state::spot_market::{SpotBalanceType, SpotMarket};
 use crate::state::user::SpotPosition;
+use crate::PERCENTAGE_PRECISION;
 
 pub fn get_spot_balance(
     token_amount: u128,


### PR DESCRIPTION
The absence of import was causing a compilation issue when compiling with `drift-rs` feature on