### PR TITLE
sdk: add option to throw on tx send errors

### DIFF
--- a/sdk/src/tx/baseTxSender.ts
+++ b/sdk/src/tx/baseTxSender.ts
@@ -44,6 +44,7 @@ export abstract class BaseTxSender implements TxSender {
 	txHandler: TxHandler;
 	trackTxLandRate?: boolean;
 	throwOnTimeoutError: boolean;
+	throwOnTransactionError: boolean;
 
 	// For landing rate calcs
 	lookbackWindowMinutes: number;
@@ -65,6 +66,7 @@ export abstract class BaseTxSender implements TxSender {
 		txLandRateLookbackWindowMinutes = DEFAULT_TX_LAND_RATE_LOOKBACK_WINDOW_MINUTES,
 		landRateToFeeFunc,
 		throwOnTimeoutError = true,
+		throwOnTransactionError = true,
 	}: {
 		connection: Connection;
 		wallet: IWallet;
@@ -78,6 +80,7 @@ export abstract class BaseTxSender implements TxSender {
 		txLandRateLookbackWindowMinutes?: number;
 		landRateToFeeFunc?: (landRate: number) => number;
 		throwOnTimeoutError?: boolean;
+		throwOnTransactionError?: boolean;
 	}) {
 		this.connection = connection;
 		this.wallet = wallet;
@@ -104,6 +107,7 @@ export abstract class BaseTxSender implements TxSender {
 		this.landRateToFeeFunc =
 			landRateToFeeFunc ?? this.defaultLandRateToFeeFunc.bind(this);
 		this.throwOnTimeoutError = throwOnTimeoutError;
+		this.throwOnTransactionError = throwOnTransactionError;
 	}
 
 	async send(

--- a/sdk/src/tx/whileValidTxSender.ts
+++ b/sdk/src/tx/whileValidTxSender.ts
@@ -69,6 +69,7 @@ export class WhileValidTxSender extends BaseTxSender {
 		txLandRateLookbackWindowMinutes,
 		landRateToFeeFunc,
 		throwOnTimeoutError = true,
+		throwOnTransactionError = true,
 	}: {
 		connection: Connection;
 		wallet: IWallet;
@@ -82,6 +83,7 @@ export class WhileValidTxSender extends BaseTxSender {
 		txLandRateLookbackWindowMinutes?: number;
 		landRateToFeeFunc?: (landRate: number) => number;
 		throwOnTimeoutError?: boolean;
+		throwOnTransactionError?: boolean;
 	}) {
 		super({
 			connection,
@@ -95,6 +97,7 @@ export class WhileValidTxSender extends BaseTxSender {
 			confirmationStrategy,
 			landRateToFeeFunc,
 			throwOnTimeoutError,
+			throwOnTransactionError,
 		});
 		this.retrySleep = retrySleep;
 
@@ -240,7 +243,7 @@ export class WhileValidTxSender extends BaseTxSender {
 
 			await this.checkConfirmationResultForError(txid, result?.value);
 
-			if (result?.value?.err) {
+			if (result?.value?.err && this.throwOnTransactionError) {
 				// Fallback error handling if there's a problem reporting the error in checkConfirmationResultForError
 				throw new SendTransactionError({
 					action: 'send',


### PR DESCRIPTION
Allows user to specify whether the underlying tx sender should throw if sendTransaction results in a tx error. Currently it does for types like the while-valid sender (new default is yes). Setting `throwOnTransactionError ` in the constructor allows user to disable this behavior