### PR TITLE
program: fix - change authority account in DeleteUser struct to mutable

### DIFF
--- a/programs/drift/src/instructions/user.rs
+++ b/programs/drift/src/instructions/user.rs
@@ -2882,6 +2882,7 @@ pub struct DeleteUser<'info> {
     pub user_stats: AccountLoader<'info, UserStats>,
     #[account(mut)]
     pub state: Box<Account<'info, State>>,
+    #[account(mut)]
     pub authority: Signer<'info>,
 }
 


### PR DESCRIPTION
The authority account in the delete_user instruction needs to be mutable for it to pass, as the authority's balance will change once the Drift user is deleted. The IDL marks this account as mutable, but the actual source code does not, so it causes issues if you add the repo as a dependency and try to make a CPI call.