### PR TITLE
sdk: enforce blockhash in getVersionedTransaction

### DIFF
--- a/sdk/src/tx/baseTxSender.ts
+++ b/sdk/src/tx/baseTxSender.ts
@@ -151,9 +151,9 @@ export abstract class BaseTxSender implements TxSender {
 	async getVersionedTransaction(
 		ixs: TransactionInstruction[],
 		lookupTableAccounts: AddressLookupTableAccount[],
-		_additionalSigners?: Array<Signer>,
-		opts?: ConfirmOptions,
-		blockhash?: BlockhashWithExpiryBlockHeight
+		additionalSigners: Array<Signer> | undefined,
+		opts: ConfirmOptions | undefined,
+		blockhash: BlockhashWithExpiryBlockHeight
 	): Promise<VersionedTransaction> {
 		return this.txHandler.generateVersionedTransaction(
 			blockhash,

--- a/sdk/src/tx/types.ts
+++ b/sdk/src/tx/types.ts
@@ -41,9 +41,9 @@ export interface TxSender {
 	getVersionedTransaction(
 		ixs: TransactionInstruction[],
 		lookupTableAccounts: AddressLookupTableAccount[],
-		additionalSigners?: Array<Signer>,
-		opts?: ConfirmOptions,
-		blockhash?: BlockhashWithExpiryBlockHeight
+		additionalSigners: Array<Signer> | undefined,
+		opts: ConfirmOptions | undefined,
+		blockhash: BlockhashWithExpiryBlockHeight
 	): Promise<VersionedTransaction>;
 
 	sendRawTransaction(


### PR DESCRIPTION
Breaking change to `BaseTxSender.getVersionedTransaction`. `blockhash` was marked optional but is required by the internal `txHandler.generateVersionedTransaction`, so if a user passes an undefined blockhash, it will throw within `txHandler.generateVersionedTransaction`. Blockhash must be provided now.