### PR TITLE
Add a crate local msg! macro that can compile out

### DIFF
--- a/programs/drift/src/macros.rs
+++ b/programs/drift/src/macros.rs
@@ -104,3 +104,16 @@ macro_rules! digest_struct_hex {
         hex::encode(digest_struct!($struct)).into_bytes()
     }};
 }
+
+/// same as `solana_program::msg!` but it can compile away for off-chain use
+#[macro_export]
+macro_rules! msg {
+    ($msg:expr) => {
+        #[cfg(not(feature = "drift-rs"))]
+        $crate::sol_log($msg)
+    };
+    ($($arg:tt)*) => {
+        #[cfg(not(feature = "drift-rs"))]
+        ($crate::sol_log(&format!($($arg)*)));
+    }
+}

--- a/programs/drift/src/macros.rs
+++ b/programs/drift/src/macros.rs
@@ -110,10 +110,10 @@ macro_rules! digest_struct_hex {
 macro_rules! msg {
     ($msg:expr) => {
         #[cfg(not(feature = "drift-rs"))]
-        $crate::sol_log($msg)
+        solana_program::msg!($msg)
     };
     ($($arg:tt)*) => {
         #[cfg(not(feature = "drift-rs"))]
-        ($crate::sol_log(&format!($($arg)*)));
+        (solana_program::msg!(&format!($($arg)*)));
     }
 }

--- a/programs/drift/src/math/oracle.rs
+++ b/programs/drift/src/math/oracle.rs
@@ -269,7 +269,7 @@ pub fn oracle_validity(
 
     if log_validity {
         if !has_sufficient_number_of_data_points {
-            msg!(
+            crate::msg!(
                 "Invalid {} {} Oracle: Insufficient Data Points",
                 market_type,
                 market_index
@@ -277,7 +277,7 @@ pub fn oracle_validity(
         }
 
         if is_oracle_price_nonpositive {
-            msg!(
+            crate::msg!(
                 "Invalid {} {} Oracle: Non-positive (oracle_price <=0)",
                 market_type,
                 market_index
@@ -285,7 +285,7 @@ pub fn oracle_validity(
         }
 
         if is_oracle_price_too_volatile {
-            msg!(
+            crate::msg!(
                 "Invalid {} {} Oracle: Too Volatile (last_oracle_price_twap={:?} vs oracle_price={:?})",
                 market_type,
                 market_index,
@@ -295,7 +295,7 @@ pub fn oracle_validity(
         }
 
         if is_conf_too_large {
-            msg!(
+            crate::msg!(
                 "Invalid {} {} Oracle: Confidence Too Large (is_conf_too_large={:?})",
                 market_type,
                 market_index,
@@ -304,7 +304,7 @@ pub fn oracle_validity(
         }
 
         if is_stale_for_amm || is_stale_for_margin {
-            msg!(
+            crate::msg!(
                 "Invalid {} {} Oracle: Stale (oracle_delay={:?})",
                 market_type,
                 market_index,

--- a/programs/drift/src/math/oracle.rs
+++ b/programs/drift/src/math/oracle.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::amm;


### PR DESCRIPTION
motivation: removes noisy oracle validity logs for drift-rs use
saw that there's a `log_validity` bool but can't really control it from the public API

closes #1342 