### PR TITLE
getPlaceAndTakePerpOrderIx Fix for passing a subAccountId

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -2175,7 +2175,7 @@ export class DriftClient {
 			this.getRemainingAccountMapsForUsers(params.userAccounts);
 
 		if (params.useMarketLastSlotCache) {
-			const lastUserSlot = this.getUserAccountAndSlot()?.slot;
+			const lastUserSlot = this.getUserAccountAndSlot(params.userAccounts[0].subAccountId)?.slot;
 
 			for (const [
 				marketIndex,


### PR DESCRIPTION
subAccountId param in getPlaceAndTakePerpOrderIx is not passed all the way down so it throws at getUser when you don't have a subAccountId = 0 because getUser is always evaluating subAccountId to zero with this logic: subAccountId = subAccountId ?? this.activeSubAccountId;

activeSubAccountId seems to always be zero which might be its own problem and maybe where you should start?

Reproduce:

- Initialize a new user (your first user, sub acc id = 0)
- Delete the user
- Initialize a new user (sub acc id = 1)
- client.getPlaceAndTakePerpOrderIx(pass the non zero sub acc id param)
- it tries to use your sub acc id = 0 and throws

```
Error: DriftClient has no user for user id [object Object]_6ZRD5HpC6vic6btP7yjii68ix9HZNoJr4tB9DJ4bBBGs
    at DriftClient.getUser (/home/alex/Desktop/projects/lp-bot/lp-bot/drift-worker/node_modules/@drift-labs/sdk/lib/node/driftClient.js:1082:19)
    at DriftClient.getUserAccountAndSlot (/home/alex/Desktop/projects/lp-bot/lp-bot/drift-worker/node_modules/@drift-labs/sdk/lib/node/driftClient.js:1128:21)
    at DriftClient.getRemainingAccounts (/home/alex/Desktop/projects/lp-bot/lp-bot/drift-worker/node_modules/@drift-labs/sdk/lib/node/driftClient.js:1203:45)
    at DriftClient.getPlaceAndTakePerpOrderIx (/home/alex/Desktop/projects/lp-bot/lp-bot/drift-worker/node_modules/@drift-labs/sdk/lib/node/driftClient.js:3152:40)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async process.<anonymous> (/home/alex/Desktop/projects/lp-bot/lp-bot/drift-worker/src/drift-worker.ts:280:35)
```

This fix works for me but I didn't check the whole code base to see if it breaks anything else <3