### PR TITLE
sdk: account for authority when useMarketLastSlotCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- sdk: account for authority when useMarketLastSlotCache ([#1541](https://github.com/drift-labs/protocol-v2/pull/1541))
+
 ### Breaking
 
 ## [2.114.0] - 2025-03-13

--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -2079,16 +2079,18 @@ export class DriftClient {
 	 * @param subAccountId
 	 */
 	public async forceGetUserAccount(
-		subAccountId?: number
+		subAccountId?: number,
+		authority?: PublicKey
 	): Promise<UserAccount | undefined> {
-		await this.getUser(subAccountId).fetchAccounts();
-		return this.getUser(subAccountId).getUserAccount();
+		await this.getUser(subAccountId, authority).fetchAccounts();
+		return this.getUser(subAccountId, authority).getUserAccount();
 	}
 
 	public getUserAccountAndSlot(
-		subAccountId?: number
+		subAccountId?: number,
+		authority?: PublicKey
 	): DataAndSlot<UserAccount> | undefined {
-		return this.getUser(subAccountId).getUserAccountAndSlot();
+		return this.getUser(subAccountId, authority).getUserAccountAndSlot();
 	}
 
 	public getSpotPosition(
@@ -2190,7 +2192,10 @@ export class DriftClient {
 			const lastUserSlot = this.getUserAccountAndSlot(
 				params.userAccounts.length > 0
 					? params.userAccounts[0].subAccountId
-					: this.activeSubAccountId
+					: this.activeSubAccountId,
+				params.userAccounts.length > 0
+					? params.userAccounts[0].authority
+					: this.authority
 			)?.slot;
 
 			for (const [


### PR DESCRIPTION
Fixes a bug where the `subAccountId` of an incoming `UserAccount` doesn't exist on the authority loaded into the `DriftClient` (caused an error with `getPlacesignedMsgTakerOrderIxs`)