### PR TITLE
more less logs

### DIFF
--- a/programs/drift/src/controller/amm.rs
+++ b/programs/drift/src/controller/amm.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min, Ordering};
 
 use anchor_lang::prelude::*;
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::position::PositionDirection;
 use crate::controller::repeg::apply_cost_to_market;

--- a/programs/drift/src/controller/amm.rs
+++ b/programs/drift/src/controller/amm.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min, Ordering};
 
-use anchor_lang::prelude::*;
 use crate::msg;
+use anchor_lang::prelude::*;
 
 use crate::controller::position::PositionDirection;
 use crate::controller::repeg::apply_cost_to_market;

--- a/programs/drift/src/controller/insurance.rs
+++ b/programs/drift/src/controller/insurance.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::spot_balance::{
     update_revenue_pool_balances, update_spot_balances, update_spot_market_cumulative_interest,

--- a/programs/drift/src/controller/insurance.rs
+++ b/programs/drift/src/controller/insurance.rs
@@ -1,6 +1,6 @@
+use crate::msg;
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
-use crate::msg;
 
 use crate::controller::spot_balance::{
     update_revenue_pool_balances, update_spot_balances, update_spot_market_cumulative_interest,

--- a/programs/drift/src/controller/liquidation.rs
+++ b/programs/drift/src/controller/liquidation.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use anchor_lang::prelude::*;
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::amm::get_fee_pool_tokens;
 use crate::controller::funding::settle_funding_payment;

--- a/programs/drift/src/controller/liquidation.rs
+++ b/programs/drift/src/controller/liquidation.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
-use anchor_lang::prelude::*;
 use crate::msg;
+use anchor_lang::prelude::*;
 
 use crate::controller::amm::get_fee_pool_tokens;
 use crate::controller::funding::settle_funding_payment;

--- a/programs/drift/src/controller/orders.rs
+++ b/programs/drift/src/controller/orders.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 use std::u64;
 
-use anchor_lang::prelude::*;
 use crate::msg;
+use anchor_lang::prelude::*;
 
 use crate::controller::funding::settle_funding_payment;
 use crate::controller::lp::burn_lp_shares;

--- a/programs/drift/src/controller/orders.rs
+++ b/programs/drift/src/controller/orders.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use std::u64;
 
 use anchor_lang::prelude::*;
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::funding::settle_funding_payment;
 use crate::controller::lp::burn_lp_shares;

--- a/programs/drift/src/controller/pda.rs
+++ b/programs/drift/src/controller/pda.rs
@@ -1,7 +1,7 @@
 use crate::error::{DriftResult, ErrorCode};
 use crate::validate;
 use anchor_lang::prelude::{AccountInfo, Pubkey};
-use solana_program::msg;
+use crate::msg;
 use solana_program::rent::Rent;
 
 pub fn seed_and_create_pda<'a>(

--- a/programs/drift/src/controller/pda.rs
+++ b/programs/drift/src/controller/pda.rs
@@ -1,7 +1,7 @@
 use crate::error::{DriftResult, ErrorCode};
+use crate::msg;
 use crate::validate;
 use anchor_lang::prelude::{AccountInfo, Pubkey};
-use crate::msg;
 use solana_program::rent::Rent;
 
 pub fn seed_and_create_pda<'a>(

--- a/programs/drift/src/controller/pnl.rs
+++ b/programs/drift/src/controller/pnl.rs
@@ -39,7 +39,7 @@ use crate::state::user::{MarketType, User};
 use crate::validate;
 use anchor_lang::prelude::Pubkey;
 use anchor_lang::prelude::*;
-use solana_program::msg;
+use crate::msg;
 use std::ops::DerefMut;
 
 #[cfg(test)]

--- a/programs/drift/src/controller/pnl.rs
+++ b/programs/drift/src/controller/pnl.rs
@@ -26,6 +26,7 @@ use crate::math::safe_math::SafeMath;
 use crate::math::spot_balance::get_token_amount;
 use crate::state::margin_calculation::MarginContext;
 
+use crate::msg;
 use crate::state::events::{OrderActionExplanation, SettlePnlExplanation, SettlePnlRecord};
 use crate::state::oracle_map::OracleMap;
 use crate::state::paused_operations::PerpOperation;
@@ -39,7 +40,6 @@ use crate::state::user::{MarketType, User};
 use crate::validate;
 use anchor_lang::prelude::Pubkey;
 use anchor_lang::prelude::*;
-use crate::msg;
 use std::ops::DerefMut;
 
 #[cfg(test)]

--- a/programs/drift/src/controller/position.rs
+++ b/programs/drift/src/controller/position.rs
@@ -1,6 +1,6 @@
+use crate::msg;
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
-use crate::msg;
 
 use crate::controller;
 use crate::controller::amm::SwapDirection;

--- a/programs/drift/src/controller/position.rs
+++ b/programs/drift/src/controller/position.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller;
 use crate::controller::amm::SwapDirection;

--- a/programs/drift/src/controller/repeg.rs
+++ b/programs/drift/src/controller/repeg.rs
@@ -1,8 +1,8 @@
 use std::cmp::min;
 
+use crate::msg;
 use anchor_lang::prelude::AccountInfo;
 use anchor_lang::prelude::*;
-use crate::msg;
 
 use crate::controller::amm::update_spreads;
 use crate::controller::spot_balance::update_spot_balances;

--- a/programs/drift/src/controller/repeg.rs
+++ b/programs/drift/src/controller/repeg.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use anchor_lang::prelude::AccountInfo;
 use anchor_lang::prelude::*;
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::amm::update_spreads;
 use crate::controller::spot_balance::update_spot_balances;

--- a/programs/drift/src/controller/spot_balance.rs
+++ b/programs/drift/src/controller/spot_balance.rs
@@ -2,8 +2,8 @@ use crate::math::oracle::oracle_validity;
 use crate::state::state::ValidityGuardRails;
 use std::cmp::max; //, OracleValidity};
 
-use anchor_lang::prelude::*;
 use crate::msg;
+use anchor_lang::prelude::*;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::amm::sanitize_new_price;

--- a/programs/drift/src/controller/spot_balance.rs
+++ b/programs/drift/src/controller/spot_balance.rs
@@ -3,7 +3,7 @@ use crate::state::state::ValidityGuardRails;
 use std::cmp::max; //, OracleValidity};
 
 use anchor_lang::prelude::*;
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::amm::sanitize_new_price;

--- a/programs/drift/src/controller/spot_position.rs
+++ b/programs/drift/src/controller/spot_position.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::position::PositionDirection;
 use crate::controller::spot_balance::update_spot_balances;

--- a/programs/drift/src/instructions/admin.rs
+++ b/programs/drift/src/instructions/admin.rs
@@ -9,7 +9,7 @@ use phoenix::quantities::WrapperU64;
 use pyth_solana_receiver_sdk::cpi::accounts::InitPriceUpdate;
 use pyth_solana_receiver_sdk::program::PythSolanaReceiver;
 use serum_dex::state::ToAlignedBytes;
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::token::close_vault;
 use crate::error::ErrorCode;

--- a/programs/drift/src/instructions/admin.rs
+++ b/programs/drift/src/instructions/admin.rs
@@ -1,6 +1,7 @@
 use std::convert::identity;
 use std::mem::size_of;
 
+use crate::msg;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
 use anchor_spl::token_2022::Token2022;
@@ -9,7 +10,6 @@ use phoenix::quantities::WrapperU64;
 use pyth_solana_receiver_sdk::cpi::accounts::InitPriceUpdate;
 use pyth_solana_receiver_sdk::program::PythSolanaReceiver;
 use serum_dex::state::ToAlignedBytes;
-use crate::msg;
 
 use crate::controller::token::close_vault;
 use crate::error::ErrorCode;

--- a/programs/drift/src/instructions/constraints.rs
+++ b/programs/drift/src/instructions/constraints.rs
@@ -4,13 +4,13 @@ use anchor_lang::accounts::signer::Signer;
 use anchor_lang::prelude::{AccountInfo, Pubkey};
 
 use crate::error::ErrorCode;
+use crate::msg;
 use crate::state::insurance_fund_stake::InsuranceFundStake;
 use crate::state::perp_market::{MarketStatus, PerpMarket};
 use crate::state::spot_market::SpotMarket;
 use crate::state::state::{ExchangeStatus, State};
 use crate::state::user::{User, UserStats};
 use crate::validate;
-use crate::msg;
 
 pub fn can_sign_for_user(user: &AccountLoader<User>, signer: &Signer) -> anchor_lang::Result<bool> {
     user.load().map(|user| {

--- a/programs/drift/src/instructions/constraints.rs
+++ b/programs/drift/src/instructions/constraints.rs
@@ -10,7 +10,7 @@ use crate::state::spot_market::SpotMarket;
 use crate::state::state::{ExchangeStatus, State};
 use crate::state::user::{User, UserStats};
 use crate::validate;
-use solana_program::msg;
+use crate::msg;
 
 pub fn can_sign_for_user(user: &AccountLoader<User>, signer: &Signer) -> anchor_lang::Result<bool> {
     user.load().map(|user| {

--- a/programs/drift/src/instructions/optional_accounts.rs
+++ b/programs/drift/src/instructions/optional_accounts.rs
@@ -22,7 +22,7 @@ use anchor_spl::token::TokenAccount;
 use anchor_spl::token_interface::{Mint, TokenInterface};
 use arrayref::array_ref;
 use solana_program::account_info::next_account_info;
-use solana_program::msg;
+use crate::msg;
 use std::iter::Peekable;
 use std::ops::Deref;
 use std::slice::Iter;

--- a/programs/drift/src/instructions/optional_accounts.rs
+++ b/programs/drift/src/instructions/optional_accounts.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 
 use crate::error::ErrorCode::UnableToLoadOracle;
 use crate::math::safe_unwrap::SafeUnwrap;
+use crate::msg;
 use crate::state::load_ref::load_ref_mut;
 use crate::state::oracle::PrelaunchOracle;
 use crate::state::oracle_map::OracleMap;
@@ -22,7 +23,6 @@ use anchor_spl::token::TokenAccount;
 use anchor_spl::token_interface::{Mint, TokenInterface};
 use arrayref::array_ref;
 use solana_program::account_info::next_account_info;
-use crate::msg;
 use std::iter::Peekable;
 use std::ops::Deref;
 use std::slice::Iter;

--- a/programs/drift/src/math/amm.rs
+++ b/programs/drift/src/math/amm.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::amm::SwapDirection;
 use crate::controller::position::PositionDirection;

--- a/programs/drift/src/math/amm_spread.rs
+++ b/programs/drift/src/math/amm_spread.rs
@@ -1,6 +1,6 @@
 use std::cmp::{max, min};
 
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::position::PositionDirection;
 use crate::error::{DriftResult, ErrorCode};

--- a/programs/drift/src/math/auction.rs
+++ b/programs/drift/src/math/auction.rs
@@ -4,9 +4,9 @@ use crate::math::casting::Cast;
 use crate::math::constants::AUCTION_DERIVE_PRICE_FRACTION;
 use crate::math::orders::standardize_price;
 use crate::math::safe_math::SafeMath;
+use crate::msg;
 use crate::state::oracle::OraclePriceData;
 use crate::state::user::{Order, OrderType};
-use crate::msg;
 
 use crate::state::fill_mode::FillMode;
 use crate::state::perp_market::{AMMAvailability, PerpMarket};

--- a/programs/drift/src/math/auction.rs
+++ b/programs/drift/src/math/auction.rs
@@ -6,7 +6,7 @@ use crate::math::orders::standardize_price;
 use crate::math::safe_math::SafeMath;
 use crate::state::oracle::OraclePriceData;
 use crate::state::user::{Order, OrderType};
-use solana_program::msg;
+use crate::msg;
 
 use crate::state::fill_mode::FillMode;
 use crate::state::perp_market::{AMMAvailability, PerpMarket};

--- a/programs/drift/src/math/casting.rs
+++ b/programs/drift/src/math/casting.rs
@@ -1,6 +1,6 @@
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::bn::U192;
-use solana_program::msg;
+use crate::msg;
 use std::convert::TryInto;
 use std::panic::Location;
 

--- a/programs/drift/src/math/cp_curve.rs
+++ b/programs/drift/src/math/cp_curve.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::amm;

--- a/programs/drift/src/math/fees.rs
+++ b/programs/drift/src/math/fees.rs
@@ -17,7 +17,7 @@ use crate::state::state::{FeeStructure, FeeTier, OrderFillerRewardStructure};
 use crate::state::user::{MarketType, UserStats};
 
 use crate::{FEE_ADJUSTMENT_MAX, QUOTE_PRECISION_U64};
-use solana_program::msg;
+use crate::msg;
 
 #[cfg(test)]
 mod tests;

--- a/programs/drift/src/math/fees.rs
+++ b/programs/drift/src/math/fees.rs
@@ -16,8 +16,8 @@ use crate::math::safe_math::SafeMath;
 use crate::state::state::{FeeStructure, FeeTier, OrderFillerRewardStructure};
 use crate::state::user::{MarketType, UserStats};
 
-use crate::{FEE_ADJUSTMENT_MAX, QUOTE_PRECISION_U64};
 use crate::msg;
+use crate::{FEE_ADJUSTMENT_MAX, QUOTE_PRECISION_U64};
 
 #[cfg(test)]
 mod tests;

--- a/programs/drift/src/math/funding.rs
+++ b/programs/drift/src/math/funding.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::bn;

--- a/programs/drift/src/math/helpers.rs
+++ b/programs/drift/src/math/helpers.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::DriftResult;
 use crate::math::bn::U192;

--- a/programs/drift/src/math/insurance.rs
+++ b/programs/drift/src/math/insurance.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::casting::Cast;

--- a/programs/drift/src/math/liquidation.rs
+++ b/programs/drift/src/math/liquidation.rs
@@ -13,6 +13,7 @@ use crate::math::safe_math::SafeMath;
 use crate::math::spot_balance::get_token_amount;
 
 use crate::math::spot_swap::calculate_swap_price;
+use crate::msg;
 use crate::state::margin_calculation::MarginContext;
 use crate::state::oracle_map::OracleMap;
 use crate::state::perp_market::PerpMarket;
@@ -24,7 +25,6 @@ use crate::{
     validate, MarketType, OrderParams, PositionDirection, BASE_PRECISION,
     LIQUIDATION_FEE_INCREASE_PER_SLOT,
 };
-use crate::msg;
 
 pub const LIQUIDATION_FEE_ADJUST_GRACE_PERIOD_SLOTS: u64 = 1_500; // ~10 minutes
 

--- a/programs/drift/src/math/liquidation.rs
+++ b/programs/drift/src/math/liquidation.rs
@@ -24,7 +24,7 @@ use crate::{
     validate, MarketType, OrderParams, PositionDirection, BASE_PRECISION,
     LIQUIDATION_FEE_INCREASE_PER_SLOT,
 };
-use solana_program::msg;
+use crate::msg;
 
 pub const LIQUIDATION_FEE_ADJUST_GRACE_PERIOD_SLOTS: u64 = 1_500; // ~10 minutes
 

--- a/programs/drift/src/math/lp.rs
+++ b/programs/drift/src/math/lp.rs
@@ -2,7 +2,7 @@ use crate::error::{DriftResult, ErrorCode};
 use crate::{
     validate, MARGIN_PRECISION_U128, PRICE_PRECISION, PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO,
 };
-use solana_program::msg;
+use crate::msg;
 use std::u64;
 
 use crate::math::amm::calculate_market_open_bids_asks;

--- a/programs/drift/src/math/lp.rs
+++ b/programs/drift/src/math/lp.rs
@@ -1,8 +1,8 @@
 use crate::error::{DriftResult, ErrorCode};
+use crate::msg;
 use crate::{
     validate, MARGIN_PRECISION_U128, PRICE_PRECISION, PRICE_TIMES_AMM_TO_QUOTE_PRECISION_RATIO,
 };
-use crate::msg;
 use std::u64;
 
 use crate::math::amm::calculate_market_open_bids_asks;

--- a/programs/drift/src/math/margin.rs
+++ b/programs/drift/src/math/margin.rs
@@ -16,6 +16,7 @@ use crate::math::oracle::{is_oracle_valid_for_action, DriftAction};
 use crate::math::spot_balance::{get_strict_token_value, get_token_value};
 
 use crate::math::safe_math::SafeMath;
+use crate::msg;
 use crate::state::margin_calculation::{MarginCalculation, MarginContext, MarketIdentifier};
 use crate::state::oracle::{OraclePriceData, StrictOraclePrice};
 use crate::state::oracle_map::OracleMap;
@@ -25,7 +26,6 @@ use crate::state::spot_market::{AssetTier, SpotBalanceType};
 use crate::state::spot_market_map::SpotMarketMap;
 use crate::state::user::{MarketType, OrderFillSimulation, PerpPosition, User};
 use num_integer::Roots;
-use solana_program::msg;
 use std::cmp::{max, min, Ordering};
 
 #[cfg(test)]

--- a/programs/drift/src/math/orders.rs
+++ b/programs/drift/src/math/orders.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 use std::ops::Sub;
 
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::position::PositionDelta;
 use crate::controller::position::PositionDirection;

--- a/programs/drift/src/math/position.rs
+++ b/programs/drift/src/math/position.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::amm::SwapDirection;
 use crate::controller::position::PositionDelta;

--- a/programs/drift/src/math/repeg.rs
+++ b/programs/drift/src/math/repeg.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min};
 
 use anchor_lang::prelude::AccountInfo;
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::*;
 use crate::math::amm;

--- a/programs/drift/src/math/repeg.rs
+++ b/programs/drift/src/math/repeg.rs
@@ -1,7 +1,7 @@
 use std::cmp::{max, min};
 
-use anchor_lang::prelude::AccountInfo;
 use crate::msg;
+use anchor_lang::prelude::AccountInfo;
 
 use crate::error::*;
 use crate::math::amm;

--- a/programs/drift/src/math/safe_math.rs
+++ b/programs/drift/src/math/safe_math.rs
@@ -2,7 +2,7 @@ use crate::error::{DriftResult, ErrorCode};
 use crate::math::bn::{U192, U256};
 use crate::math::ceil_div::CheckedCeilDiv;
 use crate::math::floor_div::CheckedFloorDiv;
-use solana_program::msg;
+use crate::msg;
 use std::panic::Location;
 
 pub trait SafeMath: Sized {

--- a/programs/drift/src/math/safe_unwrap.rs
+++ b/programs/drift/src/math/safe_unwrap.rs
@@ -1,5 +1,5 @@
 use crate::error::{DriftResult, ErrorCode};
-use solana_program::msg;
+use crate::msg;
 use std::panic::Location;
 
 pub trait SafeUnwrap {

--- a/programs/drift/src/math/spot_withdraw.rs
+++ b/programs/drift/src/math/spot_withdraw.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::casting::Cast;

--- a/programs/drift/src/state/events.rs
+++ b/programs/drift/src/state/events.rs
@@ -627,10 +627,18 @@ pub struct FuelSeasonRecord {
 }
 
 pub fn emit_stack<T: AnchorSerialize + Discriminator, const N: usize>(event: T) -> DriftResult {
-    let mut data_buf = [0u8; N];
-    let mut out_buf = [0u8; N];
+    #[cfg(not(feature = "drift-rs"))]
+    {
+        let mut data_buf = [0u8; N];
+        let mut out_buf = [0u8; N];
 
-    emit_buffers(event, &mut data_buf[..], &mut out_buf[..])
+        emit_buffers(event, &mut data_buf[..], &mut out_buf[..])
+    }
+    #[cfg(feature = "drift-rs")]
+    // don't emit anything for offchain use
+    {
+        Ok(())
+    }
 }
 
 pub fn emit_buffers<T: AnchorSerialize + Discriminator>(

--- a/programs/drift/src/state/fulfillment_params/drift.rs
+++ b/programs/drift/src/state/fulfillment_params/drift.rs
@@ -13,8 +13,8 @@ use anchor_lang::prelude::InterfaceAccount;
 use anchor_spl::token_interface::TokenAccount;
 use arrayref::array_ref;
 
-use solana_program::account_info::AccountInfo;
 use crate::msg;
+use solana_program::account_info::AccountInfo;
 use std::cell::Ref;
 
 pub struct MatchFulfillmentParams<'a> {

--- a/programs/drift/src/state/fulfillment_params/drift.rs
+++ b/programs/drift/src/state/fulfillment_params/drift.rs
@@ -14,7 +14,7 @@ use anchor_spl::token_interface::TokenAccount;
 use arrayref::array_ref;
 
 use solana_program::account_info::AccountInfo;
-use solana_program::msg;
+use crate::msg;
 use std::cell::Ref;
 
 pub struct MatchFulfillmentParams<'a> {

--- a/programs/drift/src/state/fulfillment_params/serum.rs
+++ b/programs/drift/src/state/fulfillment_params/serum.rs
@@ -8,6 +8,7 @@ use crate::math::serum::{
     calculate_serum_max_coin_qty, calculate_serum_max_native_pc_quantity,
 };
 use crate::math::spot_withdraw::validate_spot_market_vault_amount;
+use crate::msg;
 use crate::signer::get_signer_seeds;
 use crate::state::events::OrderActionExplanation;
 use crate::state::spot_fulfillment_params::{ExternalSpotFill, SpotFulfillmentParams};
@@ -27,7 +28,6 @@ use serum_dex::matching::{OrderBookState, Side};
 use serum_dex::state::Market;
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::Instruction;
-use crate::msg;
 use std::cell::Ref;
 use std::convert::TryFrom;
 use std::num::NonZeroU64;

--- a/programs/drift/src/state/fulfillment_params/serum.rs
+++ b/programs/drift/src/state/fulfillment_params/serum.rs
@@ -27,7 +27,7 @@ use serum_dex::matching::{OrderBookState, Side};
 use serum_dex::state::Market;
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::Instruction;
-use solana_program::msg;
+use crate::msg;
 use std::cell::Ref;
 use std::convert::TryFrom;
 use std::num::NonZeroU64;

--- a/programs/drift/src/state/oracle_map.rs
+++ b/programs/drift/src/state/oracle_map.rs
@@ -12,7 +12,7 @@ use anchor_lang::prelude::{AccountInfo, Pubkey};
 use anchor_lang::Discriminator;
 use anchor_lang::Key;
 use arrayref::array_ref;
-use solana_program::msg;
+use crate::msg;
 use std::collections::BTreeMap;
 use std::iter::Peekable;
 use std::slice::Iter;

--- a/programs/drift/src/state/oracle_map.rs
+++ b/programs/drift/src/state/oracle_map.rs
@@ -5,6 +5,7 @@ use crate::ids::{
 };
 use crate::math::constants::PRICE_PRECISION_I64;
 use crate::math::oracle::{oracle_validity, OracleValidity};
+use crate::msg;
 use crate::state::oracle::{get_oracle_price, OraclePriceData, OracleSource, PrelaunchOracle};
 use crate::state::state::OracleGuardRails;
 use crate::state::user::MarketType;
@@ -12,7 +13,6 @@ use anchor_lang::prelude::{AccountInfo, Pubkey};
 use anchor_lang::Discriminator;
 use anchor_lang::Key;
 use arrayref::array_ref;
-use crate::msg;
 use std::collections::BTreeMap;
 use std::iter::Peekable;
 use std::slice::Iter;

--- a/programs/drift/src/state/paused_operations.rs
+++ b/programs/drift/src/state/paused_operations.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 #[cfg(test)]
 mod tests;

--- a/programs/drift/src/state/perp_market_map.rs
+++ b/programs/drift/src/state/perp_market_map.rs
@@ -15,7 +15,7 @@ use crate::state::user::PerpPositions;
 
 use crate::math::safe_unwrap::SafeUnwrap;
 use crate::state::traits::Size;
-use solana_program::msg;
+use crate::msg;
 use std::panic::Location;
 
 use super::user::SpotPosition;

--- a/programs/drift/src/state/perp_market_map.rs
+++ b/programs/drift/src/state/perp_market_map.rs
@@ -14,8 +14,8 @@ use crate::state::perp_market::PerpMarket;
 use crate::state::user::PerpPositions;
 
 use crate::math::safe_unwrap::SafeUnwrap;
-use crate::state::traits::Size;
 use crate::msg;
+use crate::state::traits::Size;
 use std::panic::Location;
 
 use super::user::SpotPosition;

--- a/programs/drift/src/state/settle_pnl_mode.rs
+++ b/programs/drift/src/state/settle_pnl_mode.rs
@@ -1,6 +1,6 @@
 use crate::error::{DriftResult, ErrorCode};
-use borsh::{BorshDeserialize, BorshSerialize};
 use crate::msg;
+use borsh::{BorshDeserialize, BorshSerialize};
 use std::panic::Location;
 
 #[cfg(test)]

--- a/programs/drift/src/state/settle_pnl_mode.rs
+++ b/programs/drift/src/state/settle_pnl_mode.rs
@@ -1,6 +1,6 @@
 use crate::error::{DriftResult, ErrorCode};
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::msg;
+use crate::msg;
 use std::panic::Location;
 
 #[cfg(test)]

--- a/programs/drift/src/state/signed_msg_user.rs
+++ b/programs/drift/src/state/signed_msg_user.rs
@@ -8,7 +8,7 @@ use anchor_lang::*;
 use anchor_lang::{account, zero_copy};
 use borsh::{BorshDeserialize, BorshSerialize};
 use prelude::AccountInfo;
-use solana_program::msg;
+use crate::msg;
 
 use crate::state::traits::Size;
 

--- a/programs/drift/src/state/signed_msg_user.rs
+++ b/programs/drift/src/state/signed_msg_user.rs
@@ -2,13 +2,13 @@ use std::cell::{Ref, RefMut};
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::safe_unwrap::SafeUnwrap;
+use crate::msg;
 use crate::{validate, ID};
 use anchor_lang::prelude::Pubkey;
 use anchor_lang::*;
 use anchor_lang::{account, zero_copy};
 use borsh::{BorshDeserialize, BorshSerialize};
 use prelude::AccountInfo;
-use crate::msg;
 
 use crate::state::traits::Size;
 

--- a/programs/drift/src/state/spot_market_map.rs
+++ b/programs/drift/src/state/spot_market_map.rs
@@ -12,8 +12,8 @@ use anchor_lang::Discriminator;
 use arrayref::array_ref;
 
 use crate::math::safe_unwrap::SafeUnwrap;
-use crate::state::traits::Size;
 use crate::msg;
+use crate::state::traits::Size;
 use std::panic::Location;
 
 pub struct SpotMarketMap<'a>(

--- a/programs/drift/src/state/spot_market_map.rs
+++ b/programs/drift/src/state/spot_market_map.rs
@@ -13,7 +13,7 @@ use arrayref::array_ref;
 
 use crate::math::safe_unwrap::SafeUnwrap;
 use crate::state::traits::Size;
-use solana_program::msg;
+use crate::msg;
 use std::panic::Location;
 
 pub struct SpotMarketMap<'a>(

--- a/programs/drift/src/state/user.rs
+++ b/programs/drift/src/state/user.rs
@@ -22,6 +22,7 @@ use crate::math::spot_balance::{
     get_signed_token_amount, get_strict_token_value, get_token_amount, get_token_value,
 };
 use crate::math::stats::calculate_rolling_sum;
+use crate::msg;
 use crate::state::oracle::StrictOraclePrice;
 use crate::state::perp_market::{ContractType, PerpMarket};
 use crate::state::spot_market::{SpotBalance, SpotBalanceType, SpotMarket};
@@ -32,7 +33,6 @@ use crate::{safe_increment, SPOT_WEIGHT_PRECISION};
 use crate::{validate, MAX_PREDICTION_MARKET_PRICE};
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
-use crate::msg;
 use std::cmp::max;
 use std::fmt;
 use std::ops::Neg;

--- a/programs/drift/src/state/user.rs
+++ b/programs/drift/src/state/user.rs
@@ -32,7 +32,7 @@ use crate::{safe_increment, SPOT_WEIGHT_PRECISION};
 use crate::{validate, MAX_PREDICTION_MARKET_PRICE};
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::msg;
+use crate::msg;
 use std::cmp::max;
 use std::fmt;
 use std::ops::Neg;

--- a/programs/drift/src/state/user_map.rs
+++ b/programs/drift/src/state/user_map.rs
@@ -7,7 +7,7 @@ use anchor_lang::prelude::AccountLoader;
 use anchor_lang::Discriminator;
 use arrayref::array_ref;
 use solana_program::account_info::AccountInfo;
-use solana_program::msg;
+use crate::msg;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
 use std::collections::BTreeMap;

--- a/programs/drift/src/state/user_map.rs
+++ b/programs/drift/src/state/user_map.rs
@@ -1,5 +1,6 @@
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::safe_unwrap::SafeUnwrap;
+use crate::msg;
 use crate::state::traits::Size;
 use crate::state::user::{User, UserStats};
 use crate::validate;
@@ -7,7 +8,6 @@ use anchor_lang::prelude::AccountLoader;
 use anchor_lang::Discriminator;
 use arrayref::array_ref;
 use solana_program::account_info::AccountInfo;
-use crate::msg;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
 use std::collections::BTreeMap;

--- a/programs/drift/src/validation/fee_structure.rs
+++ b/programs/drift/src/validation/fee_structure.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::constants::{

--- a/programs/drift/src/validation/margin.rs
+++ b/programs/drift/src/validation/margin.rs
@@ -4,7 +4,7 @@ use crate::math::constants::{
     SPOT_IMF_PRECISION, SPOT_WEIGHT_PRECISION,
 };
 use crate::{validate, HIGH_LEVERAGE_MIN_MARGIN_RATIO};
-use solana_program::msg;
+use crate::msg;
 
 pub fn validate_margin(
     margin_ratio_initial: u32,

--- a/programs/drift/src/validation/margin.rs
+++ b/programs/drift/src/validation/margin.rs
@@ -3,8 +3,8 @@ use crate::math::constants::{
     LIQUIDATION_FEE_TO_MARGIN_PRECISION_RATIO, MAX_MARGIN_RATIO, MIN_MARGIN_RATIO,
     SPOT_IMF_PRECISION, SPOT_WEIGHT_PRECISION,
 };
-use crate::{validate, HIGH_LEVERAGE_MIN_MARGIN_RATIO};
 use crate::msg;
+use crate::{validate, HIGH_LEVERAGE_MIN_MARGIN_RATIO};
 
 pub fn validate_margin(
     margin_ratio_initial: u32,

--- a/programs/drift/src/validation/order.rs
+++ b/programs/drift/src/validation/order.rs
@@ -1,4 +1,4 @@
-use solana_program::msg;
+use crate::msg;
 
 use crate::controller::position::PositionDirection;
 use crate::error::{DriftResult, ErrorCode};

--- a/programs/drift/src/validation/perp_market.rs
+++ b/programs/drift/src/validation/perp_market.rs
@@ -4,9 +4,9 @@ use crate::math::casting::Cast;
 use crate::math::constants::MAX_BASE_ASSET_AMOUNT_WITH_AMM;
 use crate::math::safe_math::SafeMath;
 
+use crate::msg;
 use crate::state::perp_market::{MarketStatus, PerpMarket, AMM};
 use crate::{validate, BID_ASK_SPREAD_PRECISION};
-use crate::msg;
 
 #[allow(clippy::comparison_chain)]
 pub fn validate_perp_market(market: &PerpMarket) -> DriftResult {

--- a/programs/drift/src/validation/perp_market.rs
+++ b/programs/drift/src/validation/perp_market.rs
@@ -6,7 +6,7 @@ use crate::math::safe_math::SafeMath;
 
 use crate::state::perp_market::{MarketStatus, PerpMarket, AMM};
 use crate::{validate, BID_ASK_SPREAD_PRECISION};
-use solana_program::msg;
+use crate::msg;
 
 #[allow(clippy::comparison_chain)]
 pub fn validate_perp_market(market: &PerpMarket) -> DriftResult {

--- a/programs/drift/src/validation/position.rs
+++ b/programs/drift/src/validation/position.rs
@@ -5,7 +5,7 @@ use crate::math::orders::is_multiple_of_step_size;
 use crate::state::perp_market::PerpMarket;
 use crate::state::user::{PerpPosition, SpotPosition};
 use crate::validate;
-use solana_program::msg;
+use crate::msg;
 
 pub fn validate_perp_position_with_perp_market(
     position: &PerpPosition,

--- a/programs/drift/src/validation/position.rs
+++ b/programs/drift/src/validation/position.rs
@@ -2,10 +2,10 @@ use crate::error::{DriftResult, ErrorCode};
 use crate::math::casting::Cast;
 use crate::math::constants::MAX_OPEN_ORDERS;
 use crate::math::orders::is_multiple_of_step_size;
+use crate::msg;
 use crate::state::perp_market::PerpMarket;
 use crate::state::user::{PerpPosition, SpotPosition};
 use crate::validate;
-use crate::msg;
 
 pub fn validate_perp_position_with_perp_market(
     position: &PerpPosition,

--- a/programs/drift/src/validation/spot_market.rs
+++ b/programs/drift/src/validation/spot_market.rs
@@ -1,7 +1,7 @@
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::constants::SPOT_UTILIZATION_PRECISION_U32;
 use crate::validate;
-use solana_program::msg;
+use crate::msg;
 
 pub fn validate_borrow_rate(
     optimal_utilization: u32,

--- a/programs/drift/src/validation/spot_market.rs
+++ b/programs/drift/src/validation/spot_market.rs
@@ -1,7 +1,7 @@
 use crate::error::{DriftResult, ErrorCode};
 use crate::math::constants::SPOT_UTILIZATION_PRECISION_U32;
-use crate::validate;
 use crate::msg;
+use crate::validate;
 
 pub fn validate_borrow_rate(
     optimal_utilization: u32,

--- a/programs/drift/src/validation/user.rs
+++ b/programs/drift/src/validation/user.rs
@@ -1,8 +1,8 @@
 use crate::error::{DriftResult, ErrorCode};
+use crate::msg;
 use crate::state::spot_market::SpotBalanceType;
 use crate::state::user::{OrderStatus, User, UserStats};
 use crate::{validate, State, THIRTEEN_DAY};
-use crate::msg;
 
 pub fn validate_user_deletion(
     user: &User,

--- a/programs/drift/src/validation/user.rs
+++ b/programs/drift/src/validation/user.rs
@@ -2,7 +2,7 @@ use crate::error::{DriftResult, ErrorCode};
 use crate::state::spot_market::SpotBalanceType;
 use crate::state::user::{OrderStatus, User, UserStats};
 use crate::{validate, State, THIRTEEN_DAY};
-use solana_program::msg;
+use crate::msg;
 
 pub fn validate_user_deletion(
     user: &User,

--- a/programs/drift/src/validation/whitelist.rs
+++ b/programs/drift/src/validation/whitelist.rs
@@ -1,8 +1,8 @@
 use crate::error::{DriftResult, ErrorCode};
+use crate::msg;
 use crate::validate;
 use anchor_lang::prelude::{Account, Pubkey};
 use anchor_spl::token::TokenAccount;
-use crate::msg;
 
 pub fn validate_whitelist_token(
     whitelist_token: Account<TokenAccount>,

--- a/programs/drift/src/validation/whitelist.rs
+++ b/programs/drift/src/validation/whitelist.rs
@@ -2,7 +2,7 @@ use crate::error::{DriftResult, ErrorCode};
 use crate::validate;
 use anchor_lang::prelude::{Account, Pubkey};
 use anchor_spl::token::TokenAccount;
-use solana_program::msg;
+use crate::msg;
 
 pub fn validate_whitelist_token(
     whitelist_token: Account<TokenAccount>,


### PR DESCRIPTION
changes:
- disable more program logs for drift-rs
- disable `emit_stack`/events for drift-rs

replaces uses of `solana_program::msg!` with the `crate::msg!` version which compiles away for drift-rs

follow up for #1523 
