### PR TITLE
sdk: fix grpc reconnect logic

### DIFF
--- a/sdk/src/accounts/grpcAccountSubscriber.ts
+++ b/sdk/src/accounts/grpcAccountSubscriber.ts
@@ -91,6 +91,17 @@ export class grpcAccountSubscriber<T> extends WebSocketAccountSubscriber<T> {
 			entry: {},
 			transactionsStatus: {},
 		};
+
+		this.stream.on('error', (error) => {
+			// @ts-ignore
+			if (error.code === 1) {
+				// expected: 1 CANCELLED: Cancelled on client
+				return;
+			} else {
+				console.error('GRPC unexpected error caught:', error);
+			}
+		});
+
 		this.stream.on('data', (chunk: SubscribeUpdate) => {
 			if (!chunk.account) {
 				return;
@@ -172,6 +183,8 @@ export class grpcAccountSubscriber<T> extends WebSocketAccountSubscriber<T> {
 						reject(err);
 					}
 				});
+				this.stream.cancel();
+				this.stream.destroy();
 			}).catch((reason) => {
 				console.error(reason);
 				throw reason;

--- a/sdk/src/accounts/grpcProgramAccountSubscriber.ts
+++ b/sdk/src/accounts/grpcProgramAccountSubscriber.ts
@@ -119,6 +119,15 @@ export class grpcProgramAccountSubscriber<
 			entry: {},
 			transactionsStatus: {},
 		};
+		this.stream.on('error', (error) => {
+			// @ts-ignore
+			if (error.code === 1) {
+				// expected: 1 CANCELLED: Cancelled on client
+				return;
+			} else {
+				console.error('GRPC unexpected error caught:', error);
+			}
+		});
 		this.stream.on('data', (chunk: SubscribeUpdate) => {
 			if (!chunk.account) {
 				return;
@@ -206,6 +215,8 @@ export class grpcProgramAccountSubscriber<
 						reject(err);
 					}
 				});
+				this.stream.cancel();
+				this.stream.destroy();
 			}).catch((reason) => {
 				console.error(reason);
 				throw reason;

--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -8633,7 +8633,7 @@ export class DriftClient {
 					insuranceFundStake: ifStakeAccountPublicKey,
 					userStats: getUserStatsAccountPublicKey(
 						this.program.programId,
-						this.wallet.publicKey  // only allow payer to request remove own insurance fund stake account
+						this.wallet.publicKey // only allow payer to request remove own insurance fund stake account
 					),
 					authority: this.wallet.publicKey,
 					insuranceFundVault: spotMarketAccount.insuranceFund.vault,
@@ -8668,7 +8668,7 @@ export class DriftClient {
 						insuranceFundStake: ifStakeAccountPublicKey,
 						userStats: getUserStatsAccountPublicKey(
 							this.program.programId,
-							this.wallet.publicKey  // only allow payer to request remove own insurance fund stake account
+							this.wallet.publicKey // only allow payer to request remove own insurance fund stake account
 						),
 						authority: this.wallet.publicKey,
 						insuranceFundVault: spotMarketAccount.insuranceFund.vault,
@@ -8739,7 +8739,7 @@ export class DriftClient {
 					insuranceFundStake: ifStakeAccountPublicKey,
 					userStats: getUserStatsAccountPublicKey(
 						this.program.programId,
-						this.wallet.publicKey  // only allow payer to request remove own insurance fund stake account
+						this.wallet.publicKey // only allow payer to request remove own insurance fund stake account
 					),
 					authority: this.wallet.publicKey,
 					insuranceFundVault: spotMarketAccount.insuranceFund.vault,


### PR DESCRIPTION
for the [yellowstone-grpc node client](https://github.com/rpcpool/yellowstone-grpc), the [proper way to close a stream](https://github.com/rpcpool/yellowstone-grpc/issues/506#issuecomment-2572991442) is to call `stream.cancel()` and `stream.destroy()`, otherwise the client holds previous connections open, which bogs down the server and eventually _someone_ will force terminate the connection in an unpleasant way.