### PR TITLE
Compute unit price improvement

### DIFF
--- a/sdk/src/tx/txHandler.ts
+++ b/sdk/src/tx/txHandler.ts
@@ -42,9 +42,6 @@ import { DEFAULT_CONFIRMATION_OPTS } from '../config';
  * When the whileValidTxSender waits for confirmation of a given transaction, it needs the last available blockheight and blockhash used in the signature to do so. For pre-signed transactions, these values aren't attached to the transaction object by default. For a "scrappy" workaround which doesn't break backwards compatibility, the SIGNATURE_BLOCK_AND_EXPIRY property is simply attached to the transaction objects as they are created or signed in this handler despite a mismatch in the typescript types. If the values are attached to the transaction when they reach the whileValidTxSender, it can opt-in to use these values.
  */
 
-const DEV_TRY_FORCE_TX_TIMEOUTS =
-	process.env.DEV_TRY_FORCE_TX_TIMEOUTS === 'true' || false;
-
 export const COMPUTE_UNITS_DEFAULT = 200_000;
 
 const BLOCKHASH_FETCH_RETRY_COUNT = 3;
@@ -554,13 +551,7 @@ export class TxHandler {
 
 		const computeUnitsPrice = baseTxParams?.computeUnitsPrice;
 
-		if (DEV_TRY_FORCE_TX_TIMEOUTS) {
-			allIx.push(
-				ComputeBudgetProgram.setComputeUnitPrice({
-					microLamports: 0,
-				})
-			);
-		} else if (computeUnitsPrice > 0 && !hasSetComputeUnitPriceIx) {
+		if (typeof computeUnitsPrice === 'number' && computeUnitsPrice != null && !hasSetComputeUnitPriceIx) {
 			allIx.push(
 				ComputeBudgetProgram.setComputeUnitPrice({
 					microLamports: computeUnitsPrice,
@@ -603,13 +594,7 @@ export class TxHandler {
 			);
 		}
 
-		if (DEV_TRY_FORCE_TX_TIMEOUTS) {
-			tx.add(
-				ComputeBudgetProgram.setComputeUnitPrice({
-					microLamports: 0,
-				})
-			);
-		} else if (computeUnitsPrice != 0) {
+		if (typeof computeUnitsPrice === 'number' && computeUnitsPrice != null) {
 			tx.add(
 				ComputeBudgetProgram.setComputeUnitPrice({
 					microLamports: computeUnitsPrice,


### PR DESCRIPTION
Updated compute unit price logic so that they get included to transaction even when set to zero.

Key reason for this is because some wallets are adding their own fee when they detect that compute unit price is not attached to the transaction