### PR TITLE
[ FIX ] `posaune0423/fix tx fee payer`

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -1096,7 +1096,7 @@ export class DriftClient {
 					this.wallet.publicKey // only allow payer to initialize own user stats account
 				),
 				authority: this.wallet.publicKey,
-				payer: this.wallet.publicKey,
+				payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 				rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 				systemProgram: anchor.web3.SystemProgram.programId,
 				state: await this.getStatePublicKey(),
@@ -1136,7 +1136,7 @@ export class DriftClient {
 				accounts: {
 					signedMsgUserOrders: signedMsgUserAccountPublicKey,
 					authority,
-					payer: this.wallet.publicKey,
+					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 					rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 					systemProgram: anchor.web3.SystemProgram.programId,
 				},
@@ -1177,7 +1177,7 @@ export class DriftClient {
 				accounts: {
 					signedMsgUserOrders: signedMsgUserAccountPublicKey,
 					authority,
-					payer: this.wallet.publicKey,
+					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 					systemProgram: anchor.web3.SystemProgram.programId,
 					user: await getUserAccountPublicKey(
 						this.program.programId,
@@ -1315,7 +1315,7 @@ export class DriftClient {
 					authority ?? this.wallet.publicKey
 				),
 				authority: authority ?? this.wallet.publicKey,
-				payer: this.wallet.publicKey,
+				payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 				rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 				systemProgram: anchor.web3.SystemProgram.programId,
 			},
@@ -1401,7 +1401,7 @@ export class DriftClient {
 					user: userAccountPublicKey,
 					userStats: this.getUserStatsAccountPublicKey(),
 					authority: this.wallet.publicKey,
-					payer: this.wallet.publicKey,
+					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 					rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 					systemProgram: anchor.web3.SystemProgram.programId,
 					state: await this.getStatePublicKey(),
@@ -1451,7 +1451,7 @@ export class DriftClient {
 					user: userAccountPublicKey,
 					authority: this.wallet.publicKey,
 					userStats: this.getUserStatsAccountPublicKey(),
-					payer: this.wallet.publicKey,
+					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 					rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 					systemProgram: anchor.web3.SystemProgram.programId,
 				},
@@ -8624,7 +8624,7 @@ export class DriftClient {
 				this.wallet.publicKey // only allow payer to initialize own insurance fund stake account
 			),
 			authority: this.wallet.publicKey,
-			payer: this.wallet.publicKey,
+			payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 			rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 			systemProgram: anchor.web3.SystemProgram.programId,
 			state: await this.getStatePublicKey(),
@@ -9737,7 +9737,7 @@ export class DriftClient {
 		const tx = await asV0Tx({
 			connection: this.connection,
 			ixs: [pullIx],
-			payer: this.wallet.publicKey,
+			payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
 			computeUnitLimitMultiple: 1.3,
 			lookupTables: await this.fetchAllLookupTableAccounts(),
 		});

--- a/sdk/src/tx/baseTxSender.ts
+++ b/sdk/src/tx/baseTxSender.ts
@@ -173,18 +173,18 @@ export abstract class BaseTxSender implements TxSender {
 
 		if (preSigned) {
 			signedTx = tx;
-			// @ts-ignore
-		} else if (this.wallet.payer) {
-			// @ts-ignore
-			tx.sign((additionalSigners ?? []).concat(this.wallet.payer));
-			signedTx = tx;
 		} else {
+			// Sign with user first for instruction authorities
 			signedTx = await this.txHandler.signVersionedTx(
 				tx,
 				additionalSigners,
 				undefined,
 				this.wallet
 			);
+			// Add payer signature if available
+			if (this.wallet.payer) {
+				signedTx.sign([this.wallet.payer]);
+			}
 		}
 
 		if (opts === undefined) {

--- a/sdk/src/tx/txHandler.ts
+++ b/sdk/src/tx/txHandler.ts
@@ -191,7 +191,7 @@ export class TxHandler {
 
 		[wallet, confirmationOpts] = this.getProps(wallet, confirmationOpts);
 
-		tx.feePayer = wallet.publicKey;
+		tx.feePayer = wallet.payer?.publicKey ?? wallet.publicKey;
 		recentBlockhash = recentBlockhash
 			? recentBlockhash
 			: await this.getLatestBlockhashForTransaction();
@@ -398,7 +398,7 @@ export class TxHandler {
 		[wallet] = this.getProps(wallet);
 
 		const message = new TransactionMessage({
-			payerKey: wallet.publicKey,
+			payerKey: wallet.payer?.publicKey ?? wallet.publicKey,
 			recentBlockhash: recentBlockhash.blockhash,
 			instructions: ixs,
 		}).compileToLegacyMessage();
@@ -420,7 +420,7 @@ export class TxHandler {
 		[wallet] = this.getProps(wallet);
 
 		const message = new TransactionMessage({
-			payerKey: wallet.publicKey,
+			payerKey: wallet.payer?.publicKey ?? wallet.publicKey,
 			recentBlockhash: recentBlockhash.blockhash,
 			instructions: ixs,
 		}).compileToV0Message(lookupTableAccounts);
@@ -649,7 +649,8 @@ export class TxHandler {
 		for (const tx of Object.values(txsMap)) {
 			if (!tx) continue;
 			tx.recentBlockhash = recentBlockhash.blockhash;
-			tx.feePayer = wallet?.publicKey ?? this.wallet?.publicKey;
+			tx.feePayer =
+				wallet?.payer?.publicKey ?? wallet?.publicKey ?? this.wallet?.publicKey;
 
 			// @ts-ignore
 			tx.SIGNATURE_BLOCK_AND_EXPIRY = recentBlockhash;
@@ -689,7 +690,8 @@ export class TxHandler {
 		// Extra handling for legacy transactions
 		for (const [_key, tx] of filteredTxEntries) {
 			if (this.isLegacyTransaction(tx)) {
-				(tx as Transaction).feePayer = wallet.publicKey;
+				(tx as Transaction).feePayer =
+					wallet.payer?.publicKey ?? wallet.publicKey;
 			}
 		}
 


### PR DESCRIPTION
### Summary
Enable gas sponsorship without API changes by:
- Setting the transaction payer to `wallet.payer?.publicKey ?? wallet.publicKey` at message construction
- Always signing with the user (authority) and then the sponsor (payer) when present

Backward compatible for users without `wallet.payer`.

### Problem
- Drift SDK always builds transactions with payer = `wallet.publicKey` (user). When trying to sponsor and sign with a different key, signing fails:
  - web3.js enforces that only required signers in the message can sign. If the sponsor key isn’t in the message’s required signer set, `VersionedTransaction.sign` throws:
```text
Cannot sign with non signer key
```
- Additionally, there is a branch that, when `wallet.payer` is present, signs only with the payer and can omit the user signature. Many Drift instructions require the user (authority) signature → tx not confirmed / timeouts.

### Solution
- Set payer at message construction time (legacy and v0):
  - `sdk/src/tx/txHandler.ts`
    - `prepareTx`: `tx.feePayer = wallet.payer?.publicKey ?? wallet.publicKey`
    - `generateLegacyVersionedTransaction`: `payerKey: wallet.payer?.publicKey ?? wallet.publicKey`
    - `generateVersionedTransaction`: `payerKey: wallet.payer?.publicKey ?? wallet.publicKey`
    - Legacy batch helpers set `feePayer` similarly
- Ensure both user and sponsor signatures are attached:
  - `sdk/src/tx/baseTxSender.ts`
    - In `sendVersionedTransaction`, always:
      1) user signs via `wallet.signTransaction(...)`
      2) if `wallet.payer` exists, add sponsor signature: `signedTx.sign([this.wallet.payer])`

### Why this is correct
- Required signer set is fixed at message construction (payerKey + any isSigner accounts)
  - If the sponsor key isn’t the payer at compile time, it cannot sign the tx; web3.js rejects it
- Drift instructions require user (authority) signature regardless of who pays fees
  - Signing order (user → sponsor) ensures authority and payer requirements are both met
- Backward compatible
  - If `wallet.payer` is undefined, behavior is unchanged
- No API/typing changes; `IWallet` already supports `payer?: Keypair`
- `additionalSigners` semantics are preserved
  - They are used for instruction signers already in the message; they cannot replace the payer

### Changes
- Files:
  - `sdk/src/tx/txHandler.ts`: use `wallet.payer?.publicKey ?? wallet.publicKey` for payer in legacy and v0 paths; same in legacy signing/batch helpers
  - `sdk/src/tx/baseTxSender.ts`: always user-sign first; add payer signature if present
- Key snippets:
```ts
// txHandler.ts
tx.feePayer = wallet.payer?.publicKey ?? wallet.publicKey;

const message = new TransactionMessage({
  payerKey: wallet.payer?.publicKey ?? wallet.publicKey,
  recentBlockhash: recentBlockhash.blockhash,
  instructions: ixs,
});
```
```ts
// baseTxSender.ts
const signedTx = await this.txHandler.signVersionedTx(tx, additionalSigners, undefined, this.wallet);
if (this.wallet.payer) {
  signedTx.sign([this.wallet.payer]);
}
```

### Impact and risk
- Impact: Only activates when `wallet.payer` is provided; otherwise unchanged
- Risk: Low. Aligns with Solana semantics; ensures both required signatures are present

### Test considerations
- No sponsor: all flows continue to work
- With sponsor:
  - Versioned and legacy tx build and confirm with both user and sponsor signatures
  - No “Cannot sign with non signer key” errors
  - No timeouts due to missing user signature

- Additional notes: `additionalSigners` continue to work as before for instruction-level signers and are not a substitute for `payerKey`.