### PR TITLE
Revert "[ FIX ] `posaune0423/fix tx fee payer`"

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -1102,7 +1102,7 @@ export class DriftClient {
 					this.wallet.publicKey // only allow payer to initialize own user stats account
 				),
 				authority: this.wallet.publicKey,
-				payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+				payer: this.wallet.publicKey,
 				rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 				systemProgram: anchor.web3.SystemProgram.programId,
 				state: await this.getStatePublicKey(),
@@ -1142,7 +1142,7 @@ export class DriftClient {
 				accounts: {
 					signedMsgUserOrders: signedMsgUserAccountPublicKey,
 					authority,
-					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+					payer: this.wallet.publicKey,
 					rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 					systemProgram: anchor.web3.SystemProgram.programId,
 				},
@@ -1183,7 +1183,7 @@ export class DriftClient {
 				accounts: {
 					signedMsgUserOrders: signedMsgUserAccountPublicKey,
 					authority,
-					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+					payer: this.wallet.publicKey,
 					systemProgram: anchor.web3.SystemProgram.programId,
 					user: await getUserAccountPublicKey(
 						this.program.programId,
@@ -1321,7 +1321,7 @@ export class DriftClient {
 					authority ?? this.wallet.publicKey
 				),
 				authority: authority ?? this.wallet.publicKey,
-				payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+				payer: this.wallet.publicKey,
 				rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 				systemProgram: anchor.web3.SystemProgram.programId,
 			},
@@ -1407,7 +1407,7 @@ export class DriftClient {
 					user: userAccountPublicKey,
 					userStats: this.getUserStatsAccountPublicKey(),
 					authority: this.wallet.publicKey,
-					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+					payer: this.wallet.publicKey,
 					rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 					systemProgram: anchor.web3.SystemProgram.programId,
 					state: await this.getStatePublicKey(),
@@ -1457,7 +1457,7 @@ export class DriftClient {
 					user: userAccountPublicKey,
 					authority: this.wallet.publicKey,
 					userStats: this.getUserStatsAccountPublicKey(),
-					payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+					payer: this.wallet.publicKey,
 					rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 					systemProgram: anchor.web3.SystemProgram.programId,
 				},
@@ -8630,7 +8630,7 @@ export class DriftClient {
 				this.wallet.publicKey // only allow payer to initialize own insurance fund stake account
 			),
 			authority: this.wallet.publicKey,
-			payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+			payer: this.wallet.publicKey,
 			rent: anchor.web3.SYSVAR_RENT_PUBKEY,
 			systemProgram: anchor.web3.SystemProgram.programId,
 			state: await this.getStatePublicKey(),
@@ -9743,7 +9743,7 @@ export class DriftClient {
 		const tx = await asV0Tx({
 			connection: this.connection,
 			ixs: [pullIx],
-			payer: this.wallet.payer?.publicKey ?? this.wallet.publicKey,
+			payer: this.wallet.publicKey,
 			computeUnitLimitMultiple: 1.3,
 			lookupTables: await this.fetchAllLookupTableAccounts(),
 		});

--- a/sdk/src/tx/baseTxSender.ts
+++ b/sdk/src/tx/baseTxSender.ts
@@ -173,18 +173,18 @@ export abstract class BaseTxSender implements TxSender {
 
 		if (preSigned) {
 			signedTx = tx;
+			// @ts-ignore
+		} else if (this.wallet.payer) {
+			// @ts-ignore
+			tx.sign((additionalSigners ?? []).concat(this.wallet.payer));
+			signedTx = tx;
 		} else {
-			// Sign with user first for instruction authorities
 			signedTx = await this.txHandler.signVersionedTx(
 				tx,
 				additionalSigners,
 				undefined,
 				this.wallet
 			);
-			// Add payer signature if available
-			if (this.wallet.payer) {
-				signedTx.sign([this.wallet.payer]);
-			}
 		}
 
 		if (opts === undefined) {

--- a/sdk/src/tx/txHandler.ts
+++ b/sdk/src/tx/txHandler.ts
@@ -191,7 +191,7 @@ export class TxHandler {
 
 		[wallet, confirmationOpts] = this.getProps(wallet, confirmationOpts);
 
-		tx.feePayer = wallet.payer?.publicKey ?? wallet.publicKey;
+		tx.feePayer = wallet.publicKey;
 		recentBlockhash = recentBlockhash
 			? recentBlockhash
 			: await this.getLatestBlockhashForTransaction();
@@ -398,7 +398,7 @@ export class TxHandler {
 		[wallet] = this.getProps(wallet);
 
 		const message = new TransactionMessage({
-			payerKey: wallet.payer?.publicKey ?? wallet.publicKey,
+			payerKey: wallet.publicKey,
 			recentBlockhash: recentBlockhash.blockhash,
 			instructions: ixs,
 		}).compileToLegacyMessage();
@@ -420,7 +420,7 @@ export class TxHandler {
 		[wallet] = this.getProps(wallet);
 
 		const message = new TransactionMessage({
-			payerKey: wallet.payer?.publicKey ?? wallet.publicKey,
+			payerKey: wallet.publicKey,
 			recentBlockhash: recentBlockhash.blockhash,
 			instructions: ixs,
 		}).compileToV0Message(lookupTableAccounts);
@@ -649,8 +649,7 @@ export class TxHandler {
 		for (const tx of Object.values(txsMap)) {
 			if (!tx) continue;
 			tx.recentBlockhash = recentBlockhash.blockhash;
-			tx.feePayer =
-				wallet?.payer?.publicKey ?? wallet?.publicKey ?? this.wallet?.publicKey;
+			tx.feePayer = wallet?.publicKey ?? this.wallet?.publicKey;
 
 			// @ts-ignore
 			tx.SIGNATURE_BLOCK_AND_EXPIRY = recentBlockhash;
@@ -690,8 +689,7 @@ export class TxHandler {
 		// Extra handling for legacy transactions
 		for (const [_key, tx] of filteredTxEntries) {
 			if (this.isLegacyTransaction(tx)) {
-				(tx as Transaction).feePayer =
-					wallet.payer?.publicKey ?? wallet.publicKey;
+				(tx as Transaction).feePayer = wallet.publicKey;
 			}
 		}
 


### PR DESCRIPTION
Reverts drift-labs/protocol-v2#1837

caused this error in RetryTxSender:
```
TypeError: tx.partialSign is not a function
    at Wallet3.signTransaction (/lib/index.js:275679:12)
    at TxHandler.signVersionedTx (/lib/index.js:324492:39)
    at RetryTxSender2.sendVersionedTransaction (/lib/index.js:325642:43)
    at DriftClient20.sendTransaction (/lib/index.js:337010:32)
    at /lib/index.js:1080354:30
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 78)
    at async PythCrankerBot.runCrankLoop (/lib/index.js:1080278:5)
    at async Timeout._onTimeout (/lib/index.js:1080189:7)
```