### PR TITLE
sdk: support jupiter api key

### DIFF
--- a/sdk/src/jupiter/jupiterClient.ts
+++ b/sdk/src/jupiter/jupiterClient.ts
@@ -224,16 +224,48 @@ export interface QuoteResponse {
 }
 
 export const RECOMMENDED_JUPITER_API_VERSION = '/v1';
-export const RECOMMENDED_JUPITER_API = 'https://lite-api.jup.ag/swap';
+/** @deprecated Use RECOMMENDED_JUPITER_API instead. lite-api.jup.ag requires migration to api.jup.ag with API key. */
+export const LEGACY_JUPITER_API = 'https://lite-api.jup.ag/swap';
+export const RECOMMENDED_JUPITER_API = 'https://api.jup.ag/swap';
 
 export class JupiterClient {
 	url: string;
 	connection: Connection;
 	lookupTableCahce = new Map<string, AddressLookupTableAccount>();
+	private apiKey?: string;
 
-	constructor({ connection, url }: { connection: Connection; url?: string }) {
+	/**
+	 * Create a Jupiter client
+	 * @param connection - Solana connection
+	 * @param url - Optional custom API URL. Defaults to https://api.jup.ag/swap
+	 * @param apiKey - API key for Jupiter API. Required for api.jup.ag (free tier available at https://portal.jup.ag)
+	 */
+	constructor({
+		connection,
+		url,
+		apiKey,
+	}: {
+		connection: Connection;
+		url?: string;
+		apiKey?: string;
+	}) {
 		this.connection = connection;
 		this.url = url ?? RECOMMENDED_JUPITER_API;
+		this.apiKey = apiKey;
+	}
+
+	/**
+	 * Get the headers for API requests, including API key if configured
+	 */
+	private getHeaders(contentType?: string): Record<string, string> {
+		const headers: Record<string, string> = {};
+		if (contentType) {
+			headers['Content-Type'] = contentType;
+		}
+		if (this.apiKey) {
+			headers['x-api-key'] = this.apiKey;
+		}
+		return headers;
 	}
 
 	/**
@@ -289,11 +321,17 @@ export class JupiterClient {
 			params.delete('maxAccounts');
 		}
 		const apiVersionParam =
-			this.url === RECOMMENDED_JUPITER_API
+			this.url === RECOMMENDED_JUPITER_API || this.url === LEGACY_JUPITER_API
 				? RECOMMENDED_JUPITER_API_VERSION
 				: '';
+		const headers = this.getHeaders();
+		const fetchOptions: RequestInit =
+			Object.keys(headers).length > 0 ? { headers } : {};
 		const quote = await (
-			await fetch(`${this.url}${apiVersionParam}/quote?${params.toString()}`)
+			await fetch(
+				`${this.url}${apiVersionParam}/quote?${params.toString()}`,
+				fetchOptions
+			)
 		).json();
 		return quote as QuoteResponse;
 	}
@@ -318,15 +356,13 @@ export class JupiterClient {
 		}
 
 		const apiVersionParam =
-			this.url === RECOMMENDED_JUPITER_API
+			this.url === RECOMMENDED_JUPITER_API || this.url === LEGACY_JUPITER_API
 				? RECOMMENDED_JUPITER_API_VERSION
 				: '';
 		const resp = await (
 			await fetch(`${this.url}${apiVersionParam}/swap`, {
 				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-				},
+				headers: this.getHeaders('application/json'),
 				body: JSON.stringify({
 					quoteResponse: quote,
 					userPublicKey,

--- a/sdk/src/swap/UnifiedSwapClient.ts
+++ b/sdk/src/swap/UnifiedSwapClient.ts
@@ -73,6 +73,14 @@ export class UnifiedSwapClient {
 	private client: JupiterClient | TitanClient;
 	private clientType: SwapClientType;
 
+	/**
+	 * Create a unified swap client
+	 * @param clientType - 'jupiter' or 'titan'
+	 * @param connection - Solana connection
+	 * @param authToken - For Titan: auth token (required when not using proxy). For Jupiter: API key (required for api.jup.ag, get free key at https://portal.jup.ag)
+	 * @param url - Optional custom URL
+	 * @param proxyUrl - Optional proxy URL for Titan
+	 */
 	constructor({
 		clientType,
 		connection,
@@ -82,7 +90,7 @@ export class UnifiedSwapClient {
 	}: {
 		clientType: SwapClientType;
 		connection: Connection;
-		authToken?: string; // Required for Titan when not using proxy, optional for Jupiter
+		authToken?: string; // For Titan: auth token. For Jupiter: API key (required for api.jup.ag)
 		url?: string; // Optional custom URL
 		proxyUrl?: string; // Optional proxy URL for Titan
 	}) {
@@ -92,6 +100,7 @@ export class UnifiedSwapClient {
 			this.client = new JupiterClient({
 				connection,
 				url,
+				apiKey: authToken,
 			});
 		} else if (clientType === 'titan') {
 			this.client = new TitanClient({


### PR DESCRIPTION
# Summary

Jupiter is deprecating their free lite-api.jup.ag endpoint and requiring all users to migrate to api.jup.ag with an API key. This PR adds API key support to `JupiterClient` and `UnifiedSwapClient`.

Migration Guide: https://dev.jup.ag/portal/migrate-from-lite-api

# Migration Steps for Users

Get a free API key at portal.jup.ag (60 requests/minute on free tier)

Update code:
```typescript
// JupiterClient
const jupiterClient = new JupiterClient({
  connection,
  apiKey: 'your-api-key',
});

// UnifiedSwapClient
const swapClient = new UnifiedSwapClient({
  clientType: 'jupiter',
  connection,
  authToken: 'your-api-key', // reuses authToken param
});

// DriftClient.swap() - pass jupiterClient with API key
await driftClient.swap({
  jupiterClient, // created with apiKey
  // ... other params
});
```
