### PR TITLE
refactor(program): enforce escrow account loading

### DIFF
--- a/programs/drift/src/controller/orders.rs
+++ b/programs/drift/src/controller/orders.rs
@@ -2365,7 +2365,11 @@ pub fn fulfill_perp_order_with_amm(
             let order = escrow.get_order_mut(idx)?;
             order.fees_accrued = order.fees_accrued.safe_add(builder_fee)?;
         } else {
-            msg!("Order has builder fee but no escrow account found, in the future this tx will fail.");
+            validate!(
+                false,
+                ErrorCode::UnableToLoadRevenueShareAccount,
+                "Order has builder fee but no escrow account found"
+            )?;
         }
     }
 
@@ -2887,7 +2891,11 @@ pub fn fulfill_perp_order_with_match(
             let order = escrow.get_order_mut(idx)?;
             order.fees_accrued = order.fees_accrued.safe_add(builder_fee)?;
         } else {
-            msg!("Order has builder fee but no escrow account found, in the future this tx will fail.");
+            validate!(
+                false,
+                ErrorCode::UnableToLoadRevenueShareAccount,
+                "Order has builder fee but no escrow account found"
+            )?;
         }
     }
 

--- a/programs/drift/src/instructions/keeper.rs
+++ b/programs/drift/src/instructions/keeper.rs
@@ -767,7 +767,11 @@ pub fn place_signed_msg_taker_order<'c: 'info, 'info>(
             builder_fee_bps = Some(builder_fee);
             escrow_zc = Some(escrow);
         } else {
-            msg!("Order has builder fee but no escrow account found, in the future this tx will fail.");
+            validate!(
+                false,
+                ErrorCode::UnableToLoadRevenueShareAccount,
+                "Order has builder fee but no escrow account found"
+            )?;
         }
     }
 


### PR DESCRIPTION
## Summary
Enforce that SWIFT orders with builder fees must include the escrow account. Previously, missing escrow accounts only logged a warning (`msg!`) and allowed the transaction to proceed. This changes those warnings to hard errors (`validate!`) so that keepers are required to include the escrow account when filling orders with builder fees.

Relates to [BE-211](https://linear.app/driftprotocol/issue/BE-211)

## Changes
- **`instructions/keeper.rs`**: In `place_signed_msg_taker_order`, replace `msg!` warning with `validate!` error when builder codes are enabled and builder params are present but escrow account is missing
- **`controller/orders.rs`**: In `fulfill_perp_order_with_amm`, replace `msg!` warning with `validate!` error when builder fee is non-zero but escrow account or builder order index is missing
- **`controller/orders.rs`**: In `fulfill_perp_order_with_match`, same enforcement as above for matched maker fills

All three locations use `ErrorCode::UnableToLoadRevenueShareAccount` with the message "Order has builder fee but no escrow account found".

## Test plan
- [ ] Verify `cargo build --package drift` succeeds
- [ ] Verify no new test failures with `cargo test --package drift`
- [ ] Verify SWIFT orders with builder fees and a valid escrow account still succeed
- [ ] Verify SWIFT orders with builder fees but missing escrow account now return `UnableToLoadRevenueShareAccount` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced builder fee validation to enforce the requirement for a valid revenue share escrow account during fee processing. Previously the system would log warnings when escrow was unavailable; it now prevents execution with a strict validation error to ensure all configurations are complete before processing fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->