### PR TITLE
fix(sdk): add optional chaining to getSpotMarketAccountAndSlot calls

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -696,7 +696,7 @@ export class DriftClient {
 	public getSpotMarketAccount(
 		marketIndex: number
 	): SpotMarketAccount | undefined {
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)?.data;
 	}
 
 	/**
@@ -707,7 +707,7 @@ export class DriftClient {
 		marketIndex: number
 	): Promise<SpotMarketAccount | undefined> {
 		await this.accountSubscriber.fetch();
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)?.data;
 	}
 
 	public getSpotMarketAccounts(): SpotMarketAccount[] {


### PR DESCRIPTION
## Summary

Closes #2137

`getSpotMarketAccount()` and `forceGetSpotMarketAccount()` access `.data` on the return value of `getSpotMarketAccountAndSlot()` without optional chaining. If the market index doesn't exist or the account subscriber hasn't loaded yet, this throws a runtime error.

## Fix

```typescript
// Before: crashes if result is undefined
this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;

// After: returns undefined safely
this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)?.data;
```

Both occurrences fixed:
- `getSpotMarketAccount()` (line 699)
- `forceGetSpotMarketAccount()` (line 710)

The return type is already `SpotMarketAccount | undefined`, so callers already handle the undefined case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in spot market account retrieval methods to safely handle missing subscriber data without throwing exceptions, making the SDK more resilient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->