### PR TITLE
fix(sdk): optional chain getSpotMarketAccountAndSlot return in DriftClient (closes #2137)

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -696,7 +696,8 @@ export class DriftClient {
 	public getSpotMarketAccount(
 		marketIndex: number
 	): SpotMarketAccount | undefined {
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)
+			?.data;
 	}
 
 	/**
@@ -707,7 +708,8 @@ export class DriftClient {
 		marketIndex: number
 	): Promise<SpotMarketAccount | undefined> {
 		await this.accountSubscriber.fetch();
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)
+			?.data;
 	}
 
 	public getSpotMarketAccounts(): SpotMarketAccount[] {


### PR DESCRIPTION
## Summary

Closes #2137.

`getSpotMarketAccount` and `forceGetSpotMarketAccount` access `.data` on the return value of `accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)` without first checking the \`accountAndSlot\` shape. When the subscriber hasn't yet seen the account (or the market index isn't known), the subscriber returns \`undefined\` and the unguarded \`.data\` access throws \`TypeError: Cannot read properties of undefined (reading 'data')\` at runtime.

Both methods are already typed as \`... | undefined\`, so propagating \`undefined\` via optional chaining is consistent with the public contract.

## Diff

\`sdk/src/driftClient.ts\` — 4 additions, 2 deletions.

\`\`\`diff
 	public getSpotMarketAccount(
 		marketIndex: number
 	): SpotMarketAccount | undefined {
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)
+			?.data;
 	}

 	public async forceGetSpotMarketAccount(
 		marketIndex: number
 	): Promise<SpotMarketAccount | undefined> {
 		await this.accountSubscriber.fetch();
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)
+			?.data;
 	}
\`\`\`

## Test plan

- [x] Type-checks: return type already \`SpotMarketAccount | undefined\`; \`?.data\` preserves it.
- [ ] CI: existing test suite should pass unchanged (no new code paths, behavior strictly safer).
- [ ] No call sites need to change — all existing callers already handle \`undefined\` since the typed signature is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of spot market account lookups to gracefully handle missing subscriber data, preventing errors when data is unavailable and returning undefined instead of throwing exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->