### PR TITLE
fix(sdk): honor nullable return type in `getSpotMarketAccount`

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -696,7 +696,7 @@ export class DriftClient {
 	public getSpotMarketAccount(
 		marketIndex: number
 	): SpotMarketAccount | undefined {
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)?.data;
 	}
 
 	/**
@@ -707,7 +707,7 @@ export class DriftClient {
 		marketIndex: number
 	): Promise<SpotMarketAccount | undefined> {
 		await this.accountSubscriber.fetch();
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)?.data;
 	}
 
 	public getSpotMarketAccounts(): SpotMarketAccount[] {


### PR DESCRIPTION
`driftClient.getSpotMarketAccount()` and `forceGetSpotMarketAccount()` are declared to return `SpotMarketAccount | undefined`, but currently dereference `.data` on the underlying `DataAndSlot<...> | undefined` returned by `accountSubscriber`.

This causes a `TypeError` when the requested `marketIndex` is not present in the subscriber cache.

Use optional chaining when accessing `.data` so the implementation matches the declared return type and correctly returns `undefined` when the account is unavailable.

This ensures external consumers can safely handle the nullable return path without encountering runtime exceptions.

Closes #2137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved error handling in spot market account retrieval methods to safely handle edge cases where market lookups may return undefined, preventing potential runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->