### PR TITLE
fix: add optional chaining to spot market account retrievals

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -696,7 +696,8 @@ export class DriftClient {
 	public getSpotMarketAccount(
 		marketIndex: number
 	): SpotMarketAccount | undefined {
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)
+			?.data;
 	}
 
 	/**
@@ -707,7 +708,8 @@ export class DriftClient {
 		marketIndex: number
 	): Promise<SpotMarketAccount | undefined> {
 		await this.accountSubscriber.fetch();
-		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex).data;
+		return this.accountSubscriber.getSpotMarketAccountAndSlot(marketIndex)
+			?.data;
 	}
 
 	public getSpotMarketAccounts(): SpotMarketAccount[] {


### PR DESCRIPTION
Add optional chaining to getSpotMarketAccount and forceGetSpotMarketAccount to prevent potential runtime errors if the account subscriber has not yet loaded the slot data.

Closes #2137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness by gracefully handling missing spot market subscriber data, preventing errors when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->