### PR TITLE
ci: pin GitHub Actions to commit SHAs (FE-4376)

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -3,7 +3,7 @@ description: "Setup Solana"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Cache Solana Tool Suite
       id: cache-solana
       with:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout changes
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Cache Solana Version
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         id: solana-cache
         with:
           path: |
@@ -33,12 +33,12 @@ jobs:
           key: solana-v${{ env.SOLANA_VERSION }}
 
       - name: Cache Soteria Build
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
         with:
           target-dir: ${{ env.PROGRAM_PATH }}.coderrect/build # Cache build files for performance
 
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,16 @@ jobs:
     name: fmt & clippy
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Install Rust nightly
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal
           override: true
           components: rustfmt, clippy
       - name: Cache build files
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
       - name: Cargo fmt
         run: cargo fmt -- --check
       - name: Cargo clippy
@@ -39,15 +39,15 @@ jobs:
     name: Unit tests
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal
           override: true
       - name: Cache build artefacts
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
       - name: Run package checks
         run: cargo check # run package checks
       - name: Run unit tests
@@ -70,9 +70,9 @@ jobs:
   yarn-prettier:
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: "24.x.x"
           registry-url: "https://registry.npmjs.org"
@@ -85,9 +85,9 @@ jobs:
   yarn-lint:
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: "24.x.x"
           registry-url: "https://registry.npmjs.org"
@@ -100,16 +100,16 @@ jobs:
     runs-on: ubicloud
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           profile: minimal
           override: true
       - name: Cache build artefacts
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # v1
         with:
           cache-on-failure: "true"
 
@@ -117,7 +117,7 @@ jobs:
 
       - name: Cache Anchor CLI
         id: cache-anchor
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/bin/anchor
           key: ${{ runner.os }}-anchor-cli-0.29.0
@@ -127,7 +127,7 @@ jobs:
         run: cargo install --git https://github.com/coral-xyz/anchor --tag v0.29.0 anchor-cli --locked
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: "24.x.x"
           registry-url: "https://registry.npmjs.org"
@@ -157,10 +157,10 @@ jobs:
     name: Verify SDK Configs
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: "24.x.x"
           registry-url: 'https://registry.npmjs.org'
@@ -196,8 +196,8 @@ jobs:
       sdk: ${{ steps.filter.outputs.sdk }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |
@@ -221,9 +221,9 @@ jobs:
     outputs:
       version: ${{ steps.git-commit.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: "24.x.x"
           registry-url: "https://registry.npmjs.org"
@@ -279,7 +279,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Notify Slack on failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
@@ -303,7 +303,7 @@ jobs:
           ]
     steps:
       - name: Checkout code with new updated version
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Emit dispatch event
         run: |
           curl -X POST \
@@ -325,8 +325,8 @@ jobs:
       program: ${{ steps.filter.outputs.program }}
     steps:
       # For pull requests it's not necessary to checkout the code
-      - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |
@@ -342,7 +342,7 @@ jobs:
     if: ${{ needs.check-for-program-version-changes.outputs.program == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Solana Verify
         run: |
@@ -354,7 +354,7 @@ jobs:
           solana-verify build --library-name drift --base-image ellipsislabs/solana:1.16.6
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: target/deploy/drift.so

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,9 +13,9 @@ jobs:
     name: Sync with snyk.io
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
       - name: Monitor on snyk.io
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@8e119fbb6c251787721d34ba683ed48eba792766 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout changes
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
-      - uses: snyk/actions/setup@master
+      - uses: snyk/actions/setup@8e119fbb6c251787721d34ba683ed48eba792766 # master
       - name: Snyk Code Scan
         run: snyk code test --org=${{ secrets.SNYK_ORG }} --severity-threshold=medium --sarif-file-output=snyk-sast.json
         env:
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload code report
         if: always()
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@231aa2c8a89117b126725a0e11897209b7118144 # v1
         with:
           sarif_file: snyk-sast.json
   sca:
@@ -45,10 +45,10 @@ jobs:
       runs-on: ubicloud
       steps:
         - name: Checkout changes
-          uses: actions/checkout@v2
+          uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
         - name: Snyk Dependency Scan
-          uses: snyk/actions/node@master
+          uses: snyk/actions/node@8e119fbb6c251787721d34ba683ed48eba792766 # master
           env:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           with:
@@ -56,6 +56,6 @@ jobs:
 
         - name: Upload dependency report
           if: always()
-          uses: github/codeql-action/upload-sarif@v1
+          uses: github/codeql-action/upload-sarif@231aa2c8a89117b126725a0e11897209b7118144 # v1
           with:
             sarif_file: snyk-sca.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
     name: Sync with snyk.io
     runs-on: ubicloud
     steps:
-      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Monitor on snyk.io
         uses: snyk/actions/node@8e119fbb6c251787721d34ba683ed48eba792766 # master
         env:


### PR DESCRIPTION
## What

Pin all floating GitHub Actions refs in this repo to full commit SHAs (with `# version` comments), across workflow files and composite `action.yml` files. SHAs are the exact commits each tag/branch currently resolves to.

## Why

Part of the org-wide GitHub Actions hardening effort ([FE-4376](https://linear.app/driftprotocol/issue/FE-4376/improve-github-actions-security)). The `drift-labs` org now has `sha_pinning_required: true` and is moving off `Allow all actions` to a selected-actions allow-list. Floating refs (`@v1`, `@master`, …) must be pinned to full SHAs first so neither the pin-enforcement policy nor the allow-list flip breaks CI. Pinning to a SHA is the actual supply-chain defense (a mutable `@master`/tag can be moved by a compromised maintainer).

## Scope

Action ref pins only — no logic changes. Behavior preserved (e.g. `dtolnay/rust-toolchain@stable` pins to the stable-branch commit whose `action.yml` still defaults to the stable channel).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions across multiple CI/CD workflows to pin dependencies to specific commit SHAs instead of floating version tags. Changes applied to Solana setup action, audit workflow, main workflow, and security scanning workflow. All actions now reference exact commits for improved configuration reproducibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->