### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GH_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/drift-labs/${{ matrix.repo }}/dispatches" \
+            "https://api.github.com/repos/velocity-exchange/${{ matrix.repo }}/dispatches" \
             -d "{\"event_type\": \"sdk-update\", \"client_payload\": {
               \"version\": \"$VERSION\"
             }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,7 +1009,7 @@ dependencies = [
 [[package]]
 name = "drift-macros"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
+source = "git+https://github.com/velocity-exchange/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
 dependencies = [
  "quote",
  "syn 1.0.92",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "phoenix-v1"
 version = "0.2.4"
-source = "git+https://github.com/drift-labs/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
+source = "git+https://github.com/velocity-exchange/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
@@ -1908,7 +1908,7 @@ checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 [[package]]
 name = "pyth-solana-receiver-sdk"
 version = "0.3.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anchor-lang",
  "hex",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "2.1.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anchor-lang",
  "bincode",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <h1 style="margin-top:20px;">Drift Protocol v2</h1>
 
   <p>
-    <a href="https://drift-labs.github.io/v2-teacher/"><img alt="Docs" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
+    <a href="https://velocity-exchange.github.io/v2-teacher/"><img alt="Docs" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
     <a href="https://discord.com/channels/849494028176588802/878700556904980500"><img alt="Discord Chat" src="https://img.shields.io/discord/889577356681945098?color=blueviolet" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/github/license/project-serum/anchor?color=blueviolet" /></a>
   </p>
@@ -22,7 +22,7 @@ SDK docs can be found [here](./sdk/README.md)
 
 # Example Bot Implementations
 
-Example bots (makers, liquidators, fillers, etc) can be found [here](https://github.com/drift-labs/keeper-bots-v2)
+Example bots (makers, liquidators, fillers, etc) can be found [here](https://github.com/velocity-exchange/keeper-bots-v2)
 
 # Building Locally
 

--- a/programs/drift/Cargo.toml
+++ b/programs/drift/Cargo.toml
@@ -23,8 +23,8 @@ solana-program = "1.16"
 anchor-spl = { version = "0.29.0", features = [] }
 pyth-client = "0.2.2"
 pyth_lazer = { path = "../pyth-lazer", features = ["no-entrypoint"] }
-pythnet-sdk = { git = "https://github.com/drift-labs/pyth-crosschain", rev = "d790d1cb4da873a949cf33ff70349b7614b232eb"}
-pyth-solana-receiver-sdk = { git = "https://github.com/drift-labs/pyth-crosschain", rev = "d790d1cb4da873a949cf33ff70349b7614b232eb"}
+pythnet-sdk = { git = "https://github.com/velocity-exchange/pyth-crosschain", rev = "d790d1cb4da873a949cf33ff70349b7614b232eb"}
+pyth-solana-receiver-sdk = { git = "https://github.com/velocity-exchange/pyth-crosschain", rev = "d790d1cb4da873a949cf33ff70349b7614b232eb"}
 bytemuck = { version = "1.4.0" }
 borsh = "0.10.3"
 hex = "0.4.3"
@@ -35,10 +35,10 @@ arrayref = "0.3.6"
 base64 = "0.13.0"
 serum_dex = { git = "https://github.com/project-serum/serum-dex", rev = "85b4f14", version = "0.5.6", features = ["no-entrypoint"] }
 enumflags2 = "0.6.4"
-phoenix-v1 = { git = "https://github.com/drift-labs/phoenix-v1", rev = "7703c5", version = "0.2.4", features = ["no-entrypoint"] }
+phoenix-v1 = { git = "https://github.com/velocity-exchange/phoenix-v1", rev = "7703c5", version = "0.2.4", features = ["no-entrypoint"] }
 solana-security-txt = "1.1.0"
 static_assertions = "1.1.0"
-drift-macros = { git = "https://github.com/drift-labs/drift-macros.git", rev = "c57d87" }
+drift-macros = { git = "https://github.com/velocity-exchange/drift-macros.git", rev = "c57d87" }
 switchboard = { path = "../switchboard", features = ["no-entrypoint"] }
 openbook-v2-light = { path = "../openbook_v2", features = ["no-entrypoint"] }
 switchboard-on-demand = { path = "../switchboard-on-demand", features = ["no-entrypoint"] }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -5,7 +5,7 @@
 
   <p>
     <a href="https://www.npmjs.com/package/@drift-labs/sdk"><img alt="SDK npm package" src="https://img.shields.io/npm/v/@drift-labs/sdk" /></a>
-    <a href="https://drift-labs.github.io/protocol-v2/sdk/"><img alt="Docs" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
+    <a href="https://velocity-exchange.github.io/protocol-v2/sdk/"><img alt="Docs" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
     <a href="https://discord.com/channels/849494028176588802/878700556904980500"><img alt="Discord Chat" src="https://img.shields.io/discord/889577356681945098?color=blueviolet" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/github/license/project-serum/anchor?color=blueviolet" /></a>
   </p>
@@ -21,18 +21,18 @@ npm i @drift-labs/sdk
 
 _Start here if you're integrating with Drift!_
 
-- [Drift v2-teacher + API Docs](https://drift-labs.github.io/v2-teacher/)
+- [Drift v2-teacher + API Docs](https://velocity-exchange.github.io/v2-teacher/)
   - Docs and examples for using the SDK in Typescript and Python
   - Useful concepts and examples when integrating Drift
   - Docs for Drift's "Data API"
-- [Typescript API docs](https://drift-labs.github.io/protocol-v2/sdk/)
+- [Typescript API docs](https://velocity-exchange.github.io/protocol-v2/sdk/)
   - JSDoc automated documentation for the Drift v2 Typescript SDK
 - [Drift docs](https://docs.drift.trade/)
   - Comprehensive universal docs for Drift
 
 ---
 
-The below is a light overview of using Solana and Drift's typescript sdk. If you want comprehensive docs with examples of how to integrate with Drift you should use the [v2-teacher docs](https://drift-labs.github.io/v2-teacher/).
+The below is a light overview of using Solana and Drift's typescript sdk. If you want comprehensive docs with examples of how to integrate with Drift you should use the [v2-teacher docs](https://velocity-exchange.github.io/v2-teacher/).
 
 ### Setting up a wallet for your program
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://www.drift.trade/",
 	"repository": {
 		"type": "git",
-		"url": "git@github.com:drift-labs/protocol-v2.git"
+		"url": "git@github.com:velocity-exchange/protocol-v2.git"
 	},
 	"scripts": {
 		"lint": "eslint './**/*.{ts,tsx}' --quiet --format unix",


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` → `github.com/velocity-exchange/` (506 occurrences in CHANGELOG.md alone, plus README, lib.rs, Cargo.toml, workflow)
- `api.github.com/repos/drift-labs/` → `api.github.com/repos/velocity-exchange/` (CI workflow dispatch)
- `drift-labs.github.io` → `velocity-exchange.github.io` (README and sdk/README.md doc badge links)
- `@drift-labs/` npm scope → `@velocity-exchange/` (sdk/package.json, cli/package.json, cli/cli.ts, sdk/bun.lock, sdk/get_events.ts, sdk/src/decode/user.ts, .eslintrc.js)
- `drift-labs` keyword in sdk/package.json keywords array → `velocity-exchange`
- Cargo git deps under `github.com/drift-labs/` (drift-macros, phoenix-v1, pyth-crosschain forks in programs/drift/Cargo.toml and Cargo.lock)

**Total files changed: 14. Total lines changed: 536.**

## Skipped (upstream-Drift historical refs)

- `AUDIT.md`: two links to `github.com/drift-labs/audits` — these reference the original Drift Protocol's audit PDFs hosted in a separate audits repo, presented as Drift's prior audit history. Left as-is because they identify where the original security audits live, not this org's own resource.

## Notes for reviewer

- The Cargo git dependencies (`drift-macros`, `phoenix-v1`, `pyth-crosschain`) point to forks under the old org. Those forks will need to be transferred or re-forked under `velocity-exchange` for Rust builds to continue resolving. Until then, the old URLs redirect but builds should still work.
- The `@velocity-exchange/sdk` npm package does not yet exist. Builds that install from the registry will break until the package is published under the new scope. The local workspace reference (`cli/package.json`: `"file:../sdk"`) is unaffected.
- `sdk/bun.lock` lock file updated to reflect the new package name; regenerate fully after merging if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation links, resource references, and project configuration to point to new repository locations.
  * Migrated dependency sources and GitHub Actions workflow configuration to align with updated organization structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->