### PR TITLE
fix(sdk): correct BigNum zero-precision formatting edge cases

### DIFF
--- a/sdk/src/factory/bigNum.ts
+++ b/sdk/src/factory/bigNum.ts
@@ -336,6 +336,12 @@ export class BigNum {
 
 		const [leftSide, rightSide] = printString.split(BigNum.delim);
 
+		// Zero precision means no fractional part; return the integer portion
+		// without a dangling decimal delimiter (e.g. '123' rather than '123.').
+		if (fixedPrecision <= 0) {
+			return leftSide;
+		}
+
 		const filledRightSide = [
 			...(rightSide ?? '').slice(0, fixedPrecision),
 			...Array(fixedPrecision).fill('0'),
@@ -525,7 +531,11 @@ export class BigNum {
 		const prefix = `${this.lt(BigNum.zero()) ? `-` : ``}$`;
 
 		const usingCustomPrecision =
-			true && (useTradePrecision || precisionOverride || decimalOverride);
+			useTradePrecision ||
+			precisionOverride ||
+			// A decimalOverride of 0 is meaningful (whole-number formatting), so
+			// test for presence rather than truthiness.
+			decimalOverride !== undefined;
 
 		let val = usingCustomPrecision
 			? this.prettyPrint(useTradePrecision, precisionOverride, decimalOverride)

--- a/sdk/tests/bn/test.ts
+++ b/sdk/tests/bn/test.ts
@@ -352,4 +352,25 @@ describe('BigNum Tests', () => {
 			new BN('123000000000').toString()
 		);
 	});
+
+	it('toFixed with zero precision has no trailing delimiter', () => {
+		// Previously returned '123.', '0.', '-5.' with a dangling decimal point.
+		expect(BigNum.from(123, 0).toFixed(0)).to.equal('123');
+		expect(BigNum.from(5, 1).toFixed(0)).to.equal('0'); // 0.5 truncates to 0
+		expect(BigNum.from(-5, 0).toFixed(0)).to.equal('-5');
+
+		// Non-zero precision is unaffected.
+		expect(BigNum.from(123, 0).toFixed(2)).to.equal('123.00');
+	});
+
+	it('toNotional honors a decimalOverride of zero', () => {
+		const val = BigNum.fromPrint('1234.56', new BN(6));
+
+		// decimalOverride of 0 should drop the fractional part entirely.
+		expect(val.toNotional(undefined, undefined, 0)).to.equal('$1,234');
+
+		// Default and non-zero overrides are unchanged.
+		expect(val.toNotional()).to.equal('$1,234.56');
+		expect(val.toNotional(undefined, undefined, 3)).to.equal('$1,234.560');
+	});
 });


### PR DESCRIPTION
## Summary

Fixes two formatting bugs in `BigNum` (`sdk/src/factory/bigNum.ts`) that surface when a **zero** argument is passed.

### 1. `toFixed(0)` leaves a dangling decimal delimiter

`toFixed` always appends the delimiter + fractional part, so zero precision produced a malformed string:

```ts
BigNum.from(123, 0).toFixed(0) // "123."  (expected "123")
BigNum.from(5, 1).toFixed(0)   // "0."    (expected "0")
BigNum.from(-5, 0).toFixed(0)  // "-5."   (expected "-5")
```

Fix: when precision is zero there is no fractional part, so return the integer portion directly.

### 2. `toNotional()` ignores a `decimalOverride` of `0`

The `usingCustomPrecision` check folded `decimalOverride` into a truthiness test, so `0` (a legitimate value meaning "whole-dollar formatting") was treated as "not provided" and fell back to the 2-decimal default:

```ts
const val = BigNum.fromPrint('1234.56', new BN(6));
val.toNotional(undefined, undefined, 0) // "$1,234.56"  (expected "$1,234")
val.toNotional(undefined, undefined, 3) // "$1,234.560" (already worked)
```

Fix: test `decimalOverride !== undefined` instead of truthiness. `prettyPrint` already handles `0` correctly downstream.

## Tests

Added two cases to `sdk/tests/bn/test.ts` covering both fixes (and asserting the non-zero / default paths are unchanged). All `BigNum` tests pass, and `prettier --check` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number formatting for zero or negative decimal precision so values no longer show an unnecessary trailing decimal separator.
  * Fixed notional formatting to correctly treat a `0` decimal override as an intentional setting, preserving expected whole-number output.
* **Tests**
  * Added coverage for formatting edge cases, including zero precision, negative values, and zero decimal overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->