### PR TITLE
Enable overflow-checks in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 [profile.release]
 lto = "fat"
 codegen-units = 1
+overflow-checks = true
 
 [profile.release.build-override]
 opt-level = 3


### PR DESCRIPTION
## Summary
- Sets `overflow-checks = true` under workspace `[profile.release]` so release builds catch integer overflow instead of wrapping by default.
- Secure-default / hardening only — no program logic changes.

## Context
Amber-authorized hardening note. Already coordinated via hello@drift.trade; opening this small PR so the release profile matches common Solana program secure defaults.

## Test plan
- [ ] Confirm tip `Cargo.toml` `[profile.release]` includes `overflow-checks = true`
- [ ] `cargo check` / usual release build still succeeds for workspace members

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added overflow checks to release builds to help detect arithmetic errors and improve runtime reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->