### PR TITLE
fix(native): bind mm-oracle kill switch to State PDA

### DIFF
--- a/programs/drift/src/instructions/admin.rs
+++ b/programs/drift/src/instructions/admin.rs
@@ -4964,6 +4964,23 @@ pub fn handle_zero_mm_oracle_fields(ctx: Context<HotAdminUpdatePerpMarket>) -> R
 }
 
 pub fn handle_update_mm_oracle_native(accounts: &[AccountInfo], data: &[u8]) -> Result<()> {
+    // Bind the kill-switch / feature-bit source to the canonical State PDA.
+    // Owner-only checks are not enough: any large Drift-owned account could spoof
+    // the enable bit at offset 982. Seeds match Initialize.state (`drift_state`).
+    assert!(
+        accounts.len() >= 4,
+        "mm oracle native path requires market, signer, clock, state"
+    );
+    let (expected_state, _) = Pubkey::find_program_address(&[b"drift_state"], &crate::ID);
+    assert!(
+        accounts[3].key == &expected_state && accounts[3].owner == &crate::ID,
+        "accounts[3] must be the drift_state PDA owned by this program"
+    );
+    assert!(
+        accounts[3].data_len() > 982,
+        "state account too short for feature_bit_flags"
+    );
+
     // Verify this ix is allowed
     let state = &accounts[3].data.borrow();
     assert!(state[982] & 1 > 0, "ix disabled by admin state");


### PR DESCRIPTION
## Summary
`handle_update_mm_oracle_native` (reached via the `[0xFF;4]` native entry in `lib.rs`) reads the MM-oracle feature enable bit from `accounts[3].data[982]` without verifying that account is the canonical `drift_state` PDA.

Owner-only hardening (see also open #2110) is necessary but not sufficient: any sufficiently large Drift-owned account could still spoof the enable bit. This PR binds `accounts[3]` to `Pubkey::find_program_address(&[b"drift_state"], program_id)` and requires program ownership + length before the feature-bit check.

Complementary to #2110 (owner/len/clock) — this change is intentionally additive and focused on PDA identity.

## Test plan
- [ ] Existing native mm-oracle crank path with correct State PDA still succeeds when the feature bit is set
- [ ] Substituting a non-`drift_state` Drift-owned account in slot 3 fails the new assert
- [ ] Review alongside #2110 for merge ordering / conflict resolution


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when updating the market-making oracle.
  * Prevented invalid or incorrectly configured state accounts from being processed.
  * Added safeguards to ensure required account data is present before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->