### PR TITLE
fix(native): bind native market writes to PerpMarket discriminator

### DIFF
--- a/programs/drift/src/instructions/admin.rs
+++ b/programs/drift/src/instructions/admin.rs
@@ -10,6 +10,7 @@ use std::mem::size_of;
 use crate::controller;
 use crate::controller::token::{close_vault, initialize_immutable_owner, initialize_token_account};
 use crate::error::ErrorCode;
+use anchor_lang::Discriminator;
 use crate::get_then_update_id;
 use crate::ids::{admin_hot_wallet, amm_spread_adjust_wallet, mm_oracle_crank_wallet};
 use crate::instructions::constraints::*;
@@ -4963,7 +4964,31 @@ pub fn handle_zero_mm_oracle_fields(ctx: Context<HotAdminUpdatePerpMarket>) -> R
     Ok(())
 }
 
+
+/// Native paths bypass Anchor account constraints — bind market writes to a real PerpMarket.
+fn require_account_is_perp_market(account: &AccountInfo) {
+    assert!(
+        account.owner == &crate::ID,
+        "perp market must be owned by this program"
+    );
+    assert!(
+        account.data_len() >= PerpMarket::SIZE,
+        "perp market account too short"
+    );
+    let data = account.data.borrow();
+    assert!(
+        data[..8] == PerpMarket::discriminator(),
+        "account must have PerpMarket discriminator"
+    );
+}
+
 pub fn handle_update_mm_oracle_native(accounts: &[AccountInfo], data: &[u8]) -> Result<()> {
+    assert!(
+        accounts.len() >= 4,
+        "mm oracle native path requires market, signer, clock, state"
+    );
+    require_account_is_perp_market(&accounts[0]);
+
     // Verify this ix is allowed
     let state = &accounts[3].data.borrow();
     assert!(state[982] & 1 > 0, "ix disabled by admin state");
@@ -5002,6 +5027,12 @@ pub fn handle_update_amm_spread_adjustment_native(
     accounts: &[AccountInfo],
     data: &[u8],
 ) -> Result<()> {
+    assert!(
+        !accounts.is_empty(),
+        "amm spread native path requires market account"
+    );
+    require_account_is_perp_market(&accounts[0]);
+
     let signer_account = &accounts[1];
     #[cfg(not(feature = "anchor-test"))]
     assert!(

--- a/programs/drift/src/instructions/admin.rs
+++ b/programs/drift/src/instructions/admin.rs
@@ -5028,8 +5028,8 @@ pub fn handle_update_amm_spread_adjustment_native(
     data: &[u8],
 ) -> Result<()> {
     assert!(
-        !accounts.is_empty(),
-        "amm spread native path requires market account"
+        accounts.len() >= 2,
+        "amm spread native path requires market and signer accounts"
     );
     require_account_is_perp_market(&accounts[0]);
 


### PR DESCRIPTION
## Summary
The native `[0xFF;4]` handlers (`handle_update_mm_oracle_native`, `handle_update_amm_spread_adjustment_native`) write fixed byte offsets into `accounts[0]` without verifying that account is a `PerpMarket`.

Community [#2110](https://github.com/velocity-exchange/protocol-v2/pull/2110) adds owner/min-len (and Clock) checks; [#2204](https://github.com/velocity-exchange/protocol-v2/pull/2204) binds the State PDA for the kill-switch bit. This PR is additive: before the mutable borrow, require program ownership, `PerpMarket::SIZE`, and `PerpMarket::discriminator()` — the same pattern used in `PerpMarketMap`.

## Test plan
- [ ] Crank path with a real PerpMarket still updates mm-oracle / spread fields
- [ ] Substituting a non-PerpMarket Drift-owned account in slot 0 fails the new assert
- [ ] Review merge order with #2110 / #2204 (same file)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for native market-update operations to ensure required accounts are provided.
  * Added checks confirming market accounts are owned by the correct program, have sufficient data, and contain valid market metadata.
  * Improved validation for native AMM spread updates to prevent invalid or malformed account data from being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->